### PR TITLE
Unbundled consent on user registration

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/extras/_register_form.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/extras/_register_form.scss
@@ -1,9 +1,0 @@
-.lopd-text{
-  padding: .5rem;
-  border: 1px solid #e8e8e8;
-  margin: 1rem 0;
-  max-height: 10rem;
-  overflow: auto;
-  font-size: .8rem;
-  font-style: italic;
-}

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_signup.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_signup.scss
@@ -52,4 +52,9 @@
     font-size: .8rem;
     font-style: italic;
   }
+
+  #card__tos,
+  #card__newsletter{
+    text-align: center;
+  }
 }

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_signup.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_signup.scss
@@ -25,19 +25,31 @@
 }
 
 .register-form{
-  margin-top: 2rem;
-
   input[type="text"],
   input[type="email"],
   input[type="password"]{
     height: 3rem;
   }
 
-  .button{
-    margin: 2rem 0;
+  legend{
+    font-size: 1.25em;
+    line-height: 1.2;
+    margin-bottom: 1.5rem;
+    margin-top: 0;
+    text-align: center;
   }
 
-  legend{
+  label > [type='checkbox']{
     margin-bottom: 1rem;
+  }
+
+  .tos-text{
+    padding: .5rem;
+    border: 1px solid #e8e8e8;
+    margin: 1rem 0;
+    max-height: 10rem;
+    overflow: auto;
+    font-size: .8rem;
+    font-style: italic;
   }
 }

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -1,5 +1,9 @@
 <% add_decidim_page_title(t(".sign_up")) %>
 
+<% content_for :devise_links do %>
+  <%= render "decidim/devise/shared/links" %>
+<% end %>
+
 <main class="wrapper">
 <div class="row collapse">
   <div class="row collapse">
@@ -17,13 +21,13 @@
 
   <div class="row">
     <div class="columns large-6 medium-10 medium-centered">
-      <div class="card">
-        <div class="card__content">
-          <%= decidim_form_for(@form, as: resource_name, url: registration_path(resource_name), html: { class: "register-form new_user" }) do |f| %>
-            <%= invisible_captcha %>
 
+      <%= decidim_form_for(@form, as: resource_name, url: registration_path(resource_name), html: { class: "register-form new_user" }) do |f| %>
+        <%= invisible_captcha %>
+        <div class="card">
+          <div class="card__content">
             <fieldset class="text-center">
-              <legend class="text-center heading5"><%= t(".sign_up_as.legend") %></legend>
+              <legend><%= t(".sign_up_as.legend") %></legend>
               <%= f.collection_radio_buttons :sign_up_as, [["user", t(".sign_up_as.user")], ["user_group", t(".sign_up_as.user_group") ]], :first, :last %>
             </fieldset>
 
@@ -64,30 +68,46 @@
                 <%= f.text_field :user_group_phone %>
               </div>
             </div>
+          </div>
+        </div>
 
-            <p class="lopd-text">
+        <div class="card">
+          <div class="card__content">
+            <legend><%= t(".tos_title") %></legend>
+            <p class="tos-text">
               <%= strip_tags(translated_attribute(terms_and_conditions_page.content)) %>
             </p>
 
+            <div class="field">
+              <%= f.check_box :tos_agreement, label: t(".tos_agreement", link: link_to(t(".terms"), page_path("terms-and-conditions"))) %>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="card__content">
+            <h5 class="heading5 text-center"><%= t(".newsletter_title") %></h5>
             <fieldset>
               <div class="field">
                 <%= f.check_box :newsletter, label: t(".newsletter"), checked: true %>
               </div>
 
-              <div class="field">
-                <%= f.check_box :tos_agreement, label: t(".tos_agreement", link: link_to(t(".terms"), page_path("terms-and-conditions"))) %>
-              </div>
             </fieldset>
+          </div>
+        </div>
 
+        <div class="card">
+          <div class="card__content">
             <div class="actions">
               <%= f.submit t("devise.registrations.new.sign_up"), class: "button expanded" %>
             </div>
-          <% end %>
-          <%= render "decidim/devise/shared/links" %>
+            <%= yield :devise_links %>
+          </div>
         </div>
-      </div>
+      <% end %>
     </div>
   </div>
+
   <%= render "decidim/devise/shared/omniauth_buttons" %>
 </div>
 </main>

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -74,6 +74,7 @@
         <div class="card" id="card__tos">
           <div class="card__content">
             <legend><%= t(".tos_title") %></legend>
+
             <p class="tos-text">
               <%= strip_tags(translated_attribute(terms_and_conditions_page.content)) %>
             </p>
@@ -86,12 +87,12 @@
 
         <div class="card" id="card__newsletter">
           <div class="card__content">
-            <h5 class="heading5 text-center"><%= t(".newsletter_title") %></h5>
+            <legend><%= t(".newsletter_title") %></legend>
+
             <fieldset>
               <div class="field">
-                <%= f.check_box :newsletter, label: t(".newsletter"), checked: true %>
+                <%= f.check_box :newsletter, label: t(".newsletter") %>
               </div>
-
             </fieldset>
           </div>
         </div>

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -71,7 +71,7 @@
           </div>
         </div>
 
-        <div class="card">
+        <div class="card" id="card__tos">
           <div class="card__content">
             <legend><%= t(".tos_title") %></legend>
             <p class="tos-text">
@@ -84,7 +84,7 @@
           </div>
         </div>
 
-        <div class="card">
+        <div class="card" id="card__newsletter">
           <div class="card__content">
             <h5 class="heading5 text-center"><%= t(".newsletter_title") %></h5>
             <fieldset>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -192,6 +192,7 @@ en:
         new:
           already_have_an_account?: Already have an account?
           newsletter: Receive an occasional newsletter with relevant information
+          newsletter_title: Contact permission
           nickname_help: Your short, unique identifier in %{organization}
           sign_in: Log in
           sign_up: Sign up
@@ -202,6 +203,7 @@ en:
           subtitle: Sign up to participate in discussions and support proposals.
           terms: the terms and conditions of use
           tos_agreement: By signing up you agree to %{link}.
+          tos_title: Terms of Service
           username_help: Public name that appears on your posts. With the aim of guaranteeing the anonymity, can be any name.
       sessions:
         new:

--- a/decidim-core/spec/system/registration_unbundled_consent_spec.rb
+++ b/decidim-core/spec/system/registration_unbundled_consent_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "TOS", type: :system do
+  let(:organization) { create(:organization) }
+  let!(:terms_and_conditions_page) { create(:static_page, slug: "terms-and-conditions", organization: organization) }
+
+  before do
+    switch_to_host(organization.host)
+    visit decidim.new_user_registration_path
+  end
+
+  context "when in registration form" do
+    it "show tos checkbox" do
+      within("div#card__tos") do
+        expect(page).to have_content("Terms of Service")
+        expect(page).to have_css("label[for=\"user_tos_agreement\"]")
+        expect(page).to have_css("input#user_tos_agreement")
+      end
+    end
+
+    it "show tos checkbox separaterly from other input elements" do
+      within("div#card__tos") do
+        expect(page).not_to have_css("input:not(#user_tos_agreement)")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

On the user registration page, separate better what belongs to the TOS (Terms Of Service) and what belongs to the newsletter.

#### :pushpin: Related Issues
- Related to epic #3320
- Fixes #3319

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)

![photo6001104408676510663](https://user-images.githubusercontent.com/210216/39766920-c61a6e5c-52e5-11e8-95c7-059ed968bfb7.jpg)

