### PR TITLE
Add fix locale to datepicker frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ administrators should keep in mind updating the help texts for each step.
 
 **Fixed**:
 
+- **decidim-core**: Include datepicker locales in front pages too.
 - **decidim-core**: Fixes the linked_resources_for method to only show the resources that has the component published. [\#3430](https://github.com/decidim/decidim/pull/3430)
 - **decidim-accountability**: Fixes linking proposals to results for accountability on creation time. [\#3167](https://github.com/decidim/decidim/pull/3262)
 - **decidim-proposals**: Fixes clicking on "see all" should remove the ellipsis sign. [\#2894](https://github.com/decidim/decidim/pull/3238)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ administrators should keep in mind updating the help texts for each step.
 
 **Fixed**:
 
-- **decidim-core**: Include datepicker locales in front pages too.
+- **decidim-core**: Include datepicker locales in front pages too. [\#12](https://github.com/CodiTramuntana/decidim/pull/12)
 - **decidim-core**: Fixes the linked_resources_for method to only show the resources that has the component published. [\#3430](https://github.com/decidim/decidim/pull/3430)
 - **decidim-accountability**: Fixes linking proposals to results for accountability on creation time. [\#3167](https://github.com/decidim/decidim/pull/3262)
 - **decidim-proposals**: Fixes clicking on "see all" should remove the ellipsis sign. [\#2894](https://github.com/decidim/decidim/pull/3238)

--- a/decidim-admin/app/helpers/decidim/admin/application_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/application_helper.rb
@@ -16,10 +16,6 @@ module Decidim
       def title
         current_organization.name
       end
-
-      def foundation_datepicker_locale_tag
-        javascript_include_tag "datepicker-locales/foundation-datepicker.#{I18n.locale}.js" if I18n.locale != :en
-      end
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/application_helper.rb
+++ b/decidim-core/app/helpers/decidim/application_helper.rb
@@ -32,5 +32,9 @@ module Decidim
 
       presenter
     end
+
+    def foundation_datepicker_locale_tag
+      javascript_include_tag "datepicker-locales/foundation-datepicker.#{I18n.locale}.js" if I18n.locale != :en
+    end
   end
 end

--- a/decidim-core/app/helpers/decidim/application_helper.rb
+++ b/decidim-core/app/helpers/decidim/application_helper.rb
@@ -32,9 +32,5 @@ module Decidim
 
       presenter
     end
-
-    def foundation_datepicker_locale_tag
-      javascript_include_tag "datepicker-locales/foundation-datepicker.#{I18n.locale}.js" if I18n.locale != :en
-    end
   end
 end

--- a/decidim-core/app/helpers/decidim/decidim_form_helper.rb
+++ b/decidim-core/app/helpers/decidim/decidim_form_helper.rb
@@ -185,5 +185,9 @@ module Decidim
 
       alert_box(record.errors.full_messages_for(:base).join(","), "alert", false)
     end
+
+    def foundation_datepicker_locale_tag
+      javascript_include_tag "datepicker-locales/foundation-datepicker.#{I18n.locale}.js" if I18n.locale != :en
+    end
   end
 end

--- a/decidim-core/app/views/layouts/decidim/_head.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_head.html.erb
@@ -20,6 +20,7 @@
 <%= favicon %>
 <%= stylesheet_link_tag    "application", media: "all" %>
 <%= javascript_include_tag "application" %>
+<%= foundation_datepicker_locale_tag %>
 
 <%= render partial: "layouts/decidim/head_extra" %>
 <%== current_organization.header_snippets if Decidim.enable_html_header_snippets %>


### PR DESCRIPTION
#### :tophat: What? Why?
When adding a date picker to a form in the front, it is rendered always with the english locale. The right locale is only loaded in the admin zone.

This PR includes the picker locale in all of the admin and front pages, even when there is no a page using a datepicker in the front in this repository. We can remove its inclusion from the _head template and let the developers to include it only in the pages that uses it, but I think that it would be more error prone. 

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/1207


#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry


### :camera: Screenshots (optional)
![Description](URL)
