### PR TITLE
add readonly attribute to date_field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ administrators should keep in mind updating the help texts for each step.
 
 **Fixed**:
 
+- **decidim-core**: Add readonly attribute to date_field [#13](https://github.com/CodiTramuntana/decidim/pull/13)
 - **decidim-core**: Include datepicker locales in front pages too. [\#12](https://github.com/CodiTramuntana/decidim/pull/12)
 - **decidim-core**: Fixes the linked_resources_for method to only show the resources that has the component published. [\#3430](https://github.com/decidim/decidim/pull/3430)
 - **decidim-accountability**: Fixes linking proposals to results for accountability on creation time. [\#3167](https://github.com/decidim/decidim/pull/3262)

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -260,7 +260,9 @@ module Decidim
         attribute,
         options.merge(name: nil,
                       id: "date_field_#{@object_name}_#{attribute}",
-                      data: data)
+                      data: data,
+                      readonly: true
+                    )
       )
       template += @template.hidden_field(@object_name, attribute, value: iso_value)
       template += error_and_help_text(attribute, options)

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -261,8 +261,7 @@ module Decidim
         options.merge(name: nil,
                       id: "date_field_#{@object_name}_#{attribute}",
                       data: data,
-                      readonly: true
-                    )
+                      readonly: true)
       )
       template += @template.hidden_field(@object_name, attribute, value: iso_value)
       template += error_and_help_text(attribute, options)


### PR DESCRIPTION
#### :tophat: What? Why?
Add readonly to attribute date_field form builder. Because if user write manually the date, it not copy to the hidden value 

#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](URL)
