### PR TITLE
Fix components without steps to be added

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/components_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/components_controller.rb
@@ -130,6 +130,7 @@ module Decidim
         if form_params[:default_step_settings]
           form_params[:default_step_settings] = new_settings_schema(:step, form_params[:default_step_settings])
         else
+          form_params[:step_settings] ||= {}
           form_params[:step_settings].each do |key, value|
             form_params[:step_settings][key] = new_settings_schema(:step, value)
           end

--- a/decidim-sortitions/spec/system/decidim/sortitions/admin/admin_manages_sortitions_spec.rb
+++ b/decidim-sortitions/spec/system/decidim/sortitions/admin/admin_manages_sortitions_spec.rb
@@ -10,4 +10,26 @@ describe "Admin manages sortitions", type: :system do
   it_behaves_like "manage sortitions"
   it_behaves_like "cancel sortitions"
   it_behaves_like "update sortitions"
+
+  context "when adding a new sortitions module" do
+    let(:name) { "My super new sortitions component" }
+
+    it "is added" do
+      visit current_path
+      click_link "Components"
+      click_button "Add component"
+      click_link "Sortitions"
+
+      fill_in_i18n(
+        :component_name,
+        "#component-name-tabs",
+        en: name
+      )
+
+      click_button "Add component"
+
+      expect(page).to have_content("Component created successfully")
+      expect(page).to have_content(name)
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes a problem where sortitions component cannot be added to a process. 
It seems that components without step settings were failing when being added.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
