### PR TITLE
Backport "Add assemblies & processes weight field" to release/0.23 stable

### DIFF
--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly.rb
@@ -45,6 +45,7 @@ module Decidim
             organization: form.current_organization,
             title: form.title,
             subtitle: form.subtitle,
+            weight: form.weight,
             slug: form.slug,
             hashtag: form.hashtag,
             description: form.description,

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly.rb
@@ -94,7 +94,8 @@ module Decidim
             facebook_handler: form.facebook_handler,
             instagram_handler: form.instagram_handler,
             youtube_handler: form.youtube_handler,
-            github_handler: form.github_handler
+            github_handler: form.github_handler,
+            weight: form.weight
           }.merge(uploader_attributes)
         end
 

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
@@ -45,6 +45,7 @@ module Decidim
         attribute :parent_id, Integer
         attribute :participatory_processes_ids, Array[Integer]
         attribute :scope_id, Integer
+        attribute :weight, Integer
 
         attribute :is_transparent, Boolean
         attribute :promoted, Boolean

--- a/decidim-assemblies/app/queries/decidim/assemblies/organization_assemblies.rb
+++ b/decidim-assemblies/app/queries/decidim/assemblies/organization_assemblies.rb
@@ -9,7 +9,7 @@ module Decidim
       end
 
       def query
-        Decidim::Assembly.where(organization: @organization)
+        Decidim::Assembly.where(organization: @organization).order(weight: :asc)
       end
     end
   end

--- a/decidim-assemblies/app/queries/decidim/assemblies/organization_published_assemblies.rb
+++ b/decidim-assemblies/app/queries/decidim/assemblies/organization_published_assemblies.rb
@@ -14,7 +14,7 @@ module Decidim
           OrganizationAssemblies.new(@organization),
           PublishedAssemblies.new,
           VisibleAssemblies.new(@user)
-        ).query
+        ).query.order(weight: :asc)
       end
     end
   end

--- a/decidim-assemblies/app/serializers/decidim/assemblies/assembly_serializer.rb
+++ b/decidim-assemblies/app/serializers/decidim/assemblies/assembly_serializer.rb
@@ -22,6 +22,7 @@ module Decidim
           decidim_organization_id: assembly.decidim_organization_id,
           title: assembly.title,
           subtitle: assembly.subtitle,
+          weight: assembly.weight,
           short_description: assembly.short_description,
           description: assembly.description,
           remote_hero_image_url: Decidim::Assemblies::AssemblyPresenter.new(assembly).hero_image_url,

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -14,6 +14,10 @@
       <%= form.translated :text_field, :subtitle %>
     </div>
 
+    <div class="row column">
+      <%= form.number_field :weight %>
+    </div>
+
     <div class="row">
       <div class="columns xlarge-6 slug">
         <%= form.text_field :slug %>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
         target: Who participates
         title: Title
         twitter: Twitter
+        weight: Weight
         youtube: YouTube
       assembly_member:
         birthday: Birthday

--- a/decidim-assemblies/db/migrate/20210204152393_add_weight_field_to_assembly.rb
+++ b/decidim-assemblies/db/migrate/20210204152393_add_weight_field_to_assembly.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddWeightFieldToAssembly < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_assemblies, :weight, :integer, null: false, default: true
+  end
+end

--- a/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
@@ -53,6 +53,7 @@ FactoryBot.define do
     instagram_handler { "others" }
     youtube_handler { "others" }
     github_handler { "others" }
+    weight { 1 }
 
     trait :with_type do
       assembly_type { create :assemblies_type, organization: organization }

--- a/decidim-assemblies/spec/commands/create_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assembly_spec.rb
@@ -26,6 +26,7 @@ module Decidim::Assemblies
         invalid?: invalid,
         title: { en: "title" },
         subtitle: { en: "subtitle" },
+        weight: 1,
         slug: "slug",
         hashtag: "hashtag",
         meta_scope: { en: "meta scope" },

--- a/decidim-assemblies/spec/commands/update_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/update_assembly_spec.rb
@@ -31,6 +31,7 @@ module Decidim::Assemblies
             subtitle_en: my_assembly.subtitle,
             subtitle_ca: my_assembly.subtitle,
             subtitle_es: my_assembly.subtitle,
+            weight: my_assembly.weight,
             slug: my_assembly.slug,
             hashtag: my_assembly.hashtag,
             meta_scope: my_assembly.meta_scope,

--- a/decidim-assemblies/spec/controllers/admin/assemblies_controller_spec.rb
+++ b/decidim-assemblies/spec/controllers/admin/assemblies_controller_spec.rb
@@ -32,7 +32,8 @@ module Decidim
               description: assembly.description,
               short_description: assembly.short_description,
               slug: assembly.slug,
-              scopes_enabled: assembly.scopes_enabled
+              scopes_enabled: assembly.scopes_enabled,
+              weight: assembly.weight
             }
           end
 

--- a/decidim-assemblies/spec/forms/assembly_form_spec.rb
+++ b/decidim-assemblies/spec/forms/assembly_form_spec.rb
@@ -25,6 +25,7 @@ module Decidim
             ca: "Subtítol"
           }
         end
+        let(:weight) { 1 }
         let(:description) do
           {
             en: "Description",
@@ -145,6 +146,7 @@ module Decidim
               "instagram_handler" => instagram_handler,
               "youtube_handler" => youtube_handler,
               "github_handler" => github_handler,
+              "weight" => weight,
               "parent_id" => parent_id
             }
           }
@@ -329,6 +331,7 @@ module Decidim
                 instagram_handler: assembly.instagram_handler,
                 youtube_handler: assembly.youtube_handler,
                 github_handler: assembly.github_handler,
+                weight: assembly.weight,
                 parent_id: child_assembly
               }
             }
@@ -387,6 +390,7 @@ module Decidim
                 instagram_handler: assembly.instagram_handler,
                 youtube_handler: assembly.youtube_handler,
                 github_handler: assembly.github_handler,
+                weight: assembly.weight,
                 parent_id: grandchild_assembly
               }
             }

--- a/decidim-assemblies/spec/queries/organization_assemblies_spec.rb
+++ b/decidim-assemblies/spec/queries/organization_assemblies_spec.rb
@@ -8,7 +8,9 @@ module Decidim::Assemblies
 
     let!(:organization) { create(:organization) }
     let!(:local_assemblies) do
-      create_list(:assembly, 3, organization: organization)
+      create(:assembly, organization: organization, weight: 2)
+      create(:assembly, organization: organization, weight: 3)
+      create(:assembly, organization: organization, weight: 1)
     end
 
     let!(:foreign_assemblies) do
@@ -22,6 +24,10 @@ module Decidim::Assemblies
 
       it "excludes the external assemblies" do
         expect(subject).not_to include(*foreign_assemblies)
+      end
+
+      it "order assemblies by weight" do
+        expect(subject.to_a.first.weight).to eq 1
       end
     end
   end

--- a/decidim-assemblies/spec/queries/organization_published_assemblies_spec.rb
+++ b/decidim-assemblies/spec/queries/organization_published_assemblies_spec.rb
@@ -9,7 +9,9 @@ module Decidim::Assemblies
     let!(:organization) { create(:organization) }
 
     let!(:published_assemblies) do
-      create_list(:assembly, 3, :published, organization: organization)
+      create(:assembly, :published, organization: organization, weight: 2)
+      create(:assembly, :published, organization: organization, weight: 3)
+      create(:assembly, :published, organization: organization, weight: 1)
     end
 
     let!(:unpublished_assemblies) do
@@ -31,6 +33,10 @@ module Decidim::Assemblies
 
       it "excludes other organization's published assemblies" do
         expect(subject).not_to include(*foreign_assemblies)
+      end
+
+      it "order published assemblies by weight" do
+        expect(subject.to_a.first.weight).to eq 1
       end
     end
   end

--- a/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_serializer_spec.rb
+++ b/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_serializer_spec.rb
@@ -19,6 +19,7 @@ module Decidim::Assemblies
         expect(serialized).to include(decidim_organization_id: resource.decidim_organization_id)
         expect(serialized).to include(title: resource.title)
         expect(serialized).to include(subtitle: resource.subtitle)
+        expect(serialized).to include(weight: resource.weight)
         expect(serialized).to include(short_description: resource.short_description)
         expect(serialized).to include(description: resource.description)
         expect(serialized).to include(remote_hero_image_url: Decidim::Assemblies::AssemblyPresenter.new(resource).hero_image_url)

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
@@ -51,6 +51,7 @@ describe "Admin manages assemblies", type: :system do
 
         fill_in :assembly_slug, with: "slug"
         fill_in :assembly_hashtag, with: "#hashtag"
+        fill_in :assembly_weight, with: 1
         attach_file :assembly_hero_image, image1_path
         attach_file :assembly_banner_image, image2_path
 

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_with_parent_selector_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_with_parent_selector_spec.rb
@@ -56,6 +56,7 @@ describe "Admin manages assemblies with parent selector", type: :system do
 
         fill_in :assembly_slug, with: "slug"
         fill_in :assembly_hashtag, with: "#hashtag"
+        fill_in :assembly_weight, with: 1
         attach_file :assembly_hero_image, image1_path
         attach_file :assembly_banner_image, image2_path
 
@@ -114,6 +115,7 @@ describe "Admin manages assemblies with parent selector", type: :system do
 
         fill_in :assembly_slug, with: "slug"
         fill_in :assembly_hashtag, with: "#hashtag"
+        fill_in :assembly_weight, with: 1
         attach_file :assembly_hero_image, image1_path
         attach_file :assembly_banner_image, image2_path
 

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
@@ -44,6 +44,7 @@ module Decidim
             organization: form.current_organization,
             title: form.title,
             subtitle: form.subtitle,
+            weight: form.weight,
             slug: form.slug,
             hashtag: form.hashtag,
             description: form.description,

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process.rb
@@ -55,6 +55,7 @@ module Decidim
           {
             title: form.title,
             subtitle: form.subtitle,
+            weight: form.weight,
             slug: form.slug,
             hashtag: form.hashtag,
             promoted: form.promoted,

--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_form.rb
@@ -32,6 +32,7 @@ module Decidim
         attribute :scope_id, Integer
         attribute :related_process_ids, Array[Integer]
         attribute :scope_type_max_depth_id, Integer
+        attribute :weight, Integer
 
         attribute :private_space, Boolean
         attribute :promoted, Boolean

--- a/decidim-participatory_processes/app/queries/decidim/participatory_processes/organization_participatory_processes.rb
+++ b/decidim-participatory_processes/app/queries/decidim/participatory_processes/organization_participatory_processes.rb
@@ -9,7 +9,7 @@ module Decidim
       end
 
       def query
-        Decidim::ParticipatoryProcess.where(organization: @organization)
+        Decidim::ParticipatoryProcess.where(organization: @organization).order(weight: :asc)
       end
     end
   end

--- a/decidim-participatory_processes/app/queries/decidim/participatory_processes/organization_published_participatory_processes.rb
+++ b/decidim-participatory_processes/app/queries/decidim/participatory_processes/organization_published_participatory_processes.rb
@@ -14,7 +14,7 @@ module Decidim
           OrganizationParticipatoryProcesses.new(@organization),
           VisibleParticipatoryProcesses.new(@user),
           PublishedParticipatoryProcesses.new
-        ).query
+        ).query.order(weight: :asc)
       end
     end
   end

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -14,6 +14,10 @@
       <%= form.translated :text_field, :subtitle %>
     </div>
 
+    <div class="row column">
+      <%= form.number_field :weight %>
+    </div>
+
     <div class="row">
       <div class="columns xlarge-6 slug">
         <%= form.text_field :slug %>

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -35,6 +35,7 @@ en:
         subtitle: Subtitle
         target: Who participates
         title: Title
+        weight: Weight
       participatory_process_group:
         description: Description
         hero_image: Image

--- a/decidim-participatory_processes/db/migrate/20210204154593_add_weight_field_to_participatory_processes.rb
+++ b/decidim-participatory_processes/db/migrate/20210204154593_add_weight_field_to_participatory_processes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddWeightFieldToParticipatoryProcesses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_participatory_processes, :weight, :integer, null: false, default: true
+  end
+end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     title { generate_localized_title }
     slug { generate(:participatory_process_slug) }
     subtitle { generate_localized_title }
+    weight { 1 }
     short_description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     organization

--- a/decidim-participatory_processes/spec/commands/create_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/create_participatory_process_spec.rb
@@ -13,12 +13,14 @@ module Decidim::ParticipatoryProcesses
     let(:current_user) { create :user, :admin, organization: organization }
     let(:errors) { double.as_null_object }
     let(:related_process_ids) { [] }
+    let(:weight) { 1 }
     let(:form) do
       instance_double(
         Admin::ParticipatoryProcessForm,
         invalid?: invalid,
         title: { en: "title" },
         subtitle: { en: "subtitle" },
+        weight: weight,
         slug: "slug",
         hashtag: "hashtag",
         meta_scope: { en: "meta scope" },

--- a/decidim-participatory_processes/spec/commands/update_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/update_participatory_process_spec.rb
@@ -16,6 +16,7 @@ module Decidim::ParticipatoryProcesses
             subtitle_en: my_process.subtitle,
             subtitle_ca: my_process.subtitle,
             subtitle_es: my_process.subtitle,
+            weight: my_process.weight,
             slug: my_process.slug,
             hashtag: my_process.hashtag,
             meta_scope: my_process.meta_scope,

--- a/decidim-participatory_processes/spec/controllers/admin/participatory_processes_controller_spec.rb
+++ b/decidim-participatory_processes/spec/controllers/admin/participatory_processes_controller_spec.rb
@@ -29,6 +29,7 @@ module Decidim
             {
               title: participatory_process.title,
               subtitle: participatory_process.subtitle,
+              weight: participatory_process.weight,
               description: participatory_process.description,
               short_description: participatory_process.short_description,
               slug: participatory_process.slug,

--- a/decidim-participatory_processes/spec/forms/participatory_process_form_spec.rb
+++ b/decidim-participatory_processes/spec/forms/participatory_process_form_spec.rb
@@ -23,6 +23,7 @@ module Decidim
             ca: "Subtítol"
           }
         end
+        let(:weight) { 1 }
         let(:description) do
           {
             en: "Description",
@@ -50,6 +51,7 @@ module Decidim
               "subtitle_en" => subtitle[:en],
               "subtitle_es" => subtitle[:es],
               "subtitle_ca" => subtitle[:ca],
+              "weight" => weight,
               "description_en" => description[:en],
               "description_es" => description[:es],
               "description_ca" => description[:ca],

--- a/decidim-participatory_processes/spec/queries/organization_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/queries/organization_participatory_processes_spec.rb
@@ -8,7 +8,9 @@ module Decidim::ParticipatoryProcesses
 
     let!(:organization) { create(:organization) }
     let!(:local_participatory_processes) do
-      create_list(:participatory_process, 3, organization: organization)
+      create(:participatory_process, organization: organization, weight: 2)
+      create(:participatory_process, organization: organization, weight: 3)
+      create(:participatory_process, organization: organization, weight: 1)
     end
 
     let!(:foreign_participatory_processes) do
@@ -22,6 +24,10 @@ module Decidim::ParticipatoryProcesses
 
       it "excludes the external processes" do
         expect(subject).not_to include(*foreign_participatory_processes)
+      end
+
+      it "order processes by weight" do
+        expect(subject.to_a.first.weight).to eq 1
       end
     end
   end

--- a/decidim-participatory_processes/spec/queries/organization_published_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/queries/organization_published_participatory_processes_spec.rb
@@ -8,10 +8,9 @@ module Decidim::ParticipatoryProcesses
 
     let!(:organization) { create(:organization) }
     let!(:published_participatory_processes) do
-      create_list(:participatory_process,
-                  3,
-                  :published,
-                  organization: organization)
+      create(:participatory_process, :published, organization: organization, weight: 2)
+      create(:participatory_process, :published, organization: organization, weight: 3)
+      create(:participatory_process, :published, organization: organization, weight: 1)
     end
 
     let!(:unpublished_participatory_processes) do
@@ -36,6 +35,10 @@ module Decidim::ParticipatoryProcesses
 
       it "excludes other organization's published processes" do
         expect(subject).not_to include(*foreign_participatory_processes)
+      end
+
+      it "order published processes by weight" do
+        expect(subject.to_a.first.weight).to eq 1
       end
     end
   end

--- a/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_processes_spec.rb
@@ -65,6 +65,7 @@ describe "Admin manages participatory processes", versioning: true, type: :syste
 
         fill_in :participatory_process_slug, with: "slug"
         fill_in :participatory_process_hashtag, with: "#hashtag"
+        fill_in :participatory_process_weight, with: 1
         attach_file :participatory_process_hero_image, image1_path
         attach_file :participatory_process_banner_image, image2_path
 


### PR DESCRIPTION
#### :tophat: What? Why?
Backport https://github.com/decidim/decidim/pull/7283 to `release/0.23-stable`

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/7283
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
