### PR TITLE
Update mimemagic gem to an existing version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -509,7 +509,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.6)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -501,7 +501,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.6)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -509,7 +509,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.6)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)


### PR DESCRIPTION
#### :tophat: What? Why?
Currently bundler says:

> Your bundle is locked to mimemagic (0.3.6), but that version could not be found
>   in any of the sources listed in your Gemfile. If you haven't changed sources,
>   that means the author of mimemagic (0.3.6) has removed it. You'll need to update
>   your bundle to a version other than mimemagic (0.3.6) that hasn't been removed
>   in order to install.
