### PR TITLE
Backport "Fix verification report with multitenants" to v0.25

### DIFF
--- a/decidim-verifications/app/commands/decidim/verifications/authorize_user.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/authorize_user.rb
@@ -7,8 +7,9 @@ module Decidim
       # Public: Initializes the command.
       #
       # handler - An AuthorizationHandler object.
-      def initialize(handler)
+      def initialize(handler, organization)
         @handler = handler
+        @organization = organization
       end
 
       # Executes the command. Broadcasts these events:
@@ -39,7 +40,7 @@ module Decidim
           event: "decidim.events.verifications.managed_user_error_event",
           event_class: Decidim::Verifications::ManagedUserErrorEvent,
           resource: conflict,
-          affected_users: Decidim::User.where(admin: true)
+          affected_users: Decidim::User.where(admin: true, organization: @organization)
         )
       end
 

--- a/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
@@ -35,7 +35,7 @@ module Decidim
       end
 
       def create
-        AuthorizeUser.call(handler) do
+        AuthorizeUser.call(handler, current_organization) do
           on(:ok) do
             flash[:notice] = t("authorizations.create.success", scope: "decidim.verifications")
             redirect_to redirect_url || authorizations_path

--- a/decidim-verifications/spec/commands/decidim/verifications/authorize_user_spec.rb
+++ b/decidim-verifications/spec/commands/decidim/verifications/authorize_user_spec.rb
@@ -4,8 +4,9 @@ require "spec_helper"
 
 module Decidim::Verifications
   describe AuthorizeUser do
-    subject { described_class.new(handler) }
+    subject { described_class.new(handler, organization) }
 
+    let(:organization) { create(:organization) }
     let(:user) { create(:user, :confirmed) }
     let(:document_number) { "12345678X" }
     let(:handler) do
@@ -107,7 +108,7 @@ module Decidim::Verifications
             event: "decidim.events.verifications.managed_user_error_event",
             event_class: Decidim::Verifications::ManagedUserErrorEvent,
             resource: conflict,
-            affected_users: Decidim::User.where(admin: true)
+            affected_users: Decidim::User.where(admin: true, organization: organization)
           )
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Backport "Fix verification report with multitenants: notify it only to admins of that organization" to release/0.25-stable

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/8929

:hearts: Thank you!
