### PR TITLE
Backport "Allow assembly admins to manage components in child assemblies" to v0.24

### DIFF
--- a/decidim-assemblies/app/models/decidim/assembly.rb
+++ b/decidim-assemblies/app/models/decidim/assembly.rb
@@ -161,7 +161,7 @@ module Decidim
     end
 
     def user_roles(role_name = nil)
-      roles = Decidim::AssemblyUserRole.where(assembly: self)
+      roles = Decidim::AssemblyUserRole.where(assembly: self_and_ancestors)
       return roles if role_name.blank?
 
       roles.where(role: role_name)

--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -229,7 +229,7 @@ module Decidim
         return unless read_assembly_list_permission_action?
         return if permission_action.subject == :assembly_list
 
-        toggle_allow(user.admin? || can_manage_assembly?)
+        toggle_allow(user.admin? || can_manage_assembly? || admin_assembly?)
       end
 
       # A moderator needs to be able to read the assembly they are assigned to,

--- a/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
+++ b/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
@@ -656,6 +656,14 @@ describe Decidim::Assemblies::Permissions do
 
         it { is_expected.to eq(true) }
       end
+
+      context "and action is :read the current assembly" do
+        let(:action) do
+          { scope: :admin, action: :read, subject: :assembly }
+        end
+
+        it { is_expected.to eq(true) }
+      end
     end
   end
 end

--- a/decidim-assemblies/spec/shared/assembly_admin_manage_assembly_components_examples.rb
+++ b/decidim-assemblies/spec/shared/assembly_admin_manage_assembly_components_examples.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+shared_examples "assembly admin manage assembly components" do
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  describe "add a component" do
+    before do
+      visit decidim_admin_assemblies.components_path(assembly)
+
+      find("button[data-toggle=add-component-dropdown]").click
+
+      within "#add-component-dropdown" do
+        find(".dummy").click
+      end
+
+      within ".new_component" do
+        fill_in_i18n(
+          :component_name,
+          "#component-name-tabs",
+          en: "My component",
+          ca: "La meva funcionalitat",
+          es: "Mi funcionalitat"
+        )
+
+        within ".global-settings" do
+          fill_in_i18n_editor(
+            :component_settings_dummy_global_translatable_text,
+            "#global-settings-dummy_global_translatable_text-tabs",
+            en: "Dummy Text"
+          )
+          all("input[type=checkbox]").last.click
+        end
+
+        within ".default-step-settings" do
+          fill_in_i18n_editor(
+            :component_default_step_settings_dummy_step_translatable_text,
+            "#default-step-settings-dummy_step_translatable_text-tabs",
+            en: "Dummy Text for Step"
+          )
+          all("input[type=checkbox]").first.click
+        end
+
+        click_button "Add component"
+      end
+    end
+
+    it "is successfully created" do
+      expect(page).to have_admin_callout("successfully")
+      expect(page).to have_content("My component")
+    end
+
+    context "and then edit it" do
+      before do
+        within find("tr", text: "My component") do
+          click_link "Configure"
+        end
+      end
+
+      it "successfully displays initial values in the form" do
+        within ".global-settings" do
+          expect(all("input[type=checkbox]").last).to be_checked
+        end
+
+        within ".default-step-settings" do
+          expect(all("input[type=checkbox]").first).to be_checked
+        end
+      end
+
+      it "successfully edits it" do
+        click_button "Update"
+
+        expect(page).to have_admin_callout("successfully")
+      end
+    end
+  end
+
+  describe "edit a component" do
+    let(:component_name) do
+      {
+        en: "My component",
+        ca: "La meva funcionalitat",
+        es: "Mi funcionalitat"
+      }
+    end
+
+    let!(:component) do
+      create(:component, name: component_name, participatory_space: assembly)
+    end
+
+    before do
+      visit decidim_admin_assemblies.components_path(assembly)
+    end
+
+    it "updates the component" do
+      within ".component-#{component.id}" do
+        click_link "Configure"
+      end
+
+      within ".edit_component" do
+        fill_in_i18n(
+          :component_name,
+          "#component-name-tabs",
+          en: "My updated component",
+          ca: "La meva funcionalitat actualitzada",
+          es: "Mi funcionalidad actualizada"
+        )
+
+        within ".global-settings" do
+          all("input[type=checkbox]").last.click
+        end
+
+        within ".default-step-settings" do
+          all("input[type=checkbox]").first.click
+        end
+
+        click_button "Update"
+      end
+
+      expect(page).to have_admin_callout("successfully")
+      expect(page).to have_content("My updated component")
+
+      within find("tr", text: "My updated component") do
+        click_link "Configure"
+      end
+
+      within ".global-settings" do
+        expect(all("input[type=checkbox]").last).to be_checked
+      end
+
+      within ".default-step-settings" do
+        expect(all("input[type=checkbox]").first).to be_checked
+      end
+    end
+  end
+
+  describe "remove a component" do
+    let(:component_name) do
+      {
+        en: "My component",
+        ca: "La meva funcionalitat",
+        es: "Mi funcionalitat"
+      }
+    end
+
+    let!(:component) do
+      create(:component, name: component_name, participatory_space: assembly)
+    end
+
+    before do
+      visit decidim_admin_assemblies.components_path(assembly)
+    end
+
+    it "removes the component" do
+      within ".component-#{component.id}" do
+        click_link "Delete"
+      end
+
+      expect(page).to have_no_content("My component")
+    end
+  end
+
+  describe "publish and unpublish a component" do
+    let!(:component) do
+      create(:component, participatory_space: assembly, published_at: published_at)
+    end
+
+    let(:published_at) { nil }
+
+    before do
+      visit decidim_admin_assemblies.components_path(assembly)
+    end
+
+    context "when the component is unpublished" do
+      it "publishes the component" do
+        within ".component-#{component.id}" do
+          click_link "Publish"
+        end
+
+        within ".component-#{component.id}" do
+          expect(page).to have_css(".action-icon--unpublish")
+        end
+      end
+
+      it "notifies its followers" do
+        follower = create(:user, organization: assembly.organization)
+        create(:follow, followable: assembly, user: follower)
+
+        within ".component-#{component.id}" do
+          click_link "Publish"
+        end
+
+        expect(enqueued_jobs.last[:args]).to include("decidim.events.components.component_published")
+      end
+    end
+
+    context "when the component is published" do
+      let(:published_at) { Time.current }
+
+      it "unpublishes the component" do
+        within ".component-#{component.id}" do
+          click_link "Unpublish"
+        end
+
+        within ".component-#{component.id}" do
+          expect(page).to have_css(".action-icon--publish")
+        end
+      end
+    end
+  end
+
+  def participatory_space
+    assembly
+  end
+
+  def participatory_space_components_path(participatory_space)
+    decidim_admin_assemblies.components_path(participatory_space)
+  end
+end

--- a/decidim-assemblies/spec/system/admin/assembly_admin_accesses_admin_sections_spec.rb
+++ b/decidim-assemblies/spec/system/admin/assembly_admin_accesses_admin_sections_spec.rb
@@ -8,23 +8,55 @@ describe "Assembly admin accesses admin sections", type: :system do
   before do
     switch_to_host(organization.host)
     login_as user, scope: :user
-    visit decidim_admin_assemblies.assemblies_path
-
-    click_link translated(assembly.title)
   end
 
-  it "can access all sections" do
-    within ".secondary-nav" do
-      expect(page).to have_content("Info")
-      expect(page).to have_content("Components")
-      expect(page).to have_content("Categories")
-      expect(page).to have_content("Attachments")
-      expect(page).to have_content("Folders")
-      expect(page).to have_content("Files")
-      expect(page).to have_content("Members")
-      expect(page).to have_content("Assembly admins")
-      expect(page).to have_content("Private users")
-      expect(page).to have_content("Moderations")
+  context "when is a mother assembly" do
+    it "can access all sections" do
+      visit decidim_admin_assemblies.assemblies_path
+      click_link translated(assembly.title)
+
+      within ".secondary-nav" do
+        expect(page).to have_content("Info")
+        expect(page).to have_content("Components")
+        expect(page).to have_content("Categories")
+        expect(page).to have_content("Attachments")
+        expect(page).to have_content("Folders")
+        expect(page).to have_content("Files")
+        expect(page).to have_content("Members")
+        expect(page).to have_content("Assembly admins")
+        expect(page).to have_content("Private users")
+        expect(page).to have_content("Moderations")
+      end
     end
+  end
+
+  context "when is a child assembly" do
+    let!(:child_assembly) { create :assembly, parent: assembly, organization: organization, hashtag: "child" }
+
+    before do
+      visit decidim_admin_assemblies.assemblies_path
+      within find("tr", text: translated(assembly.title)) do
+        click_link "Assemblies"
+      end
+
+      click_link translated(child_assembly.title)
+    end
+
+    it "can access all sections" do
+      within ".secondary-nav" do
+        expect(page).to have_content("Info")
+        expect(page).to have_content("Components")
+        expect(page).to have_content("Categories")
+        expect(page).to have_content("Attachments")
+        expect(page).to have_content("Folders")
+        expect(page).to have_content("Files")
+        expect(page).to have_content("Members")
+        expect(page).to have_content("Assembly admins")
+        expect(page).to have_content("Private users")
+        expect(page).to have_content("Moderations")
+      end
+    end
+
+    it_behaves_like "assembly admin manage assembly components"
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Backport "Allow assembly admins to manage components in child assemblies" to v0.24

#### :pushpin: Related Issues
- Related to #8955

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
