### PR TITLE
Backport "Allow assembly admins administer children assemblie" to release/0.26-stable

### DIFF
--- a/decidim-assemblies/app/models/decidim/assembly.rb
+++ b/decidim-assemblies/app/models/decidim/assembly.rb
@@ -146,7 +146,7 @@ module Decidim
     end
 
     def user_roles(role_name = nil)
-      roles = Decidim::AssemblyUserRole.where(assembly: self)
+      roles = Decidim::AssemblyUserRole.where(assembly: self_and_ancestors)
       return roles if role_name.blank?
 
       roles.where(role: role_name)

--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -221,7 +221,7 @@ module Decidim
         return unless read_assembly_list_permission_action?
         return if permission_action.subject == :assembly_list
 
-        toggle_allow(user.admin? || can_manage_assembly?)
+        toggle_allow(user.admin? || can_manage_assembly? || admin_assembly?)
       end
 
       # A moderator needs to be able to read the assembly they are assigned to,

--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -73,6 +73,8 @@ module Decidim
         user.admin? || (assembly ? can_manage_assembly?(role: :admin) : has_manageable_assemblies?)
       end
 
+      # It's an admin assembly when assembly exists and the user is allowed to
+      # manage the current assembly.
       def admin_assembly?
         assembly.present? && assembly_admin_allowed_assemblies.include?(assembly)
       end

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
@@ -82,13 +82,13 @@
                 <% end %>
               </td>
               <td class="table-list__actions">
-                <% if allowed_to? :create, :assembly, assembly: assembly %>
+                <% if allowed_to? :export, :assembly, assembly: assembly %>
                   <%= icon_link_to "data-transfer-download", assembly_export_path(assembly), t("actions.export", scope: "decidim.admin"), method: :post, class: "action-icon--export" %>
                 <% else %>
                   <span class="action-space icon"></span>
                 <% end %>
 
-                <% if allowed_to? :create, :assembly, assembly: assembly %>
+                <% if allowed_to? :copy, :assembly, assembly: assembly %>
                   <%= icon_link_to "clipboard", new_assembly_copy_path(assembly), t("actions.duplicate", scope: "decidim.admin"), class: "action-icon--copy" %>
                 <% else %>
                   <span class="action-space icon"></span>

--- a/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
+++ b/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
@@ -559,94 +559,94 @@ describe Decidim::Assemblies::Permissions do
         it { is_expected.to eq(true) }
       end
     end
+  end
 
-    describe "actions by assemblies types when user is an admin assembly" do
-      let!(:user) { create :assembly_admin, assembly: mother_assembly }
-      let(:mother_assembly) { create :assembly, parent: assembly, organization: organization, hashtag: "mother" }
-      let(:child_assembly) { create :assembly, parent: mother_assembly, organization: organization, hashtag: "child" }
+  describe "when acting with assemblies admins and children assemblies" do
+    let!(:user) { create :assembly_admin, assembly: mother_assembly }
+    let(:mother_assembly) { create :assembly, parent: assembly, organization: organization, hashtag: "mother" }
+    let(:child_assembly) { create :assembly, parent: mother_assembly, organization: organization, hashtag: "child" }
 
-      context "when assembly is a grandmother assembly" do
-        let(:context) { { assembly: assembly } }
+    context "when assembly is a grandmother assembly" do
+      let(:context) { { assembly: assembly } }
 
-        context "and action is :list" do
-          let(:action) do
-            { scope: :admin, action: :list, subject: :assembly }
-          end
-
-          it { is_expected.to eq(true) }
+      context "and action is :list" do
+        let(:action) do
+          { scope: :admin, action: :list, subject: :assembly }
         end
 
-        context "and action is :export" do
-          let(:action) do
-            { scope: :admin, action: :export, subject: :assembly }
-          end
-
-          it { is_expected.to eq(false) }
-        end
-
-        context "and action is :copy" do
-          let(:action) do
-            { scope: :admin, action: :copy, subject: :assembly }
-          end
-
-          it { is_expected.to eq(false) }
-        end
+        it { is_expected.to eq(true) }
       end
 
-      context "when assembly is a mother assembly" do
-        let(:context) { { assembly: mother_assembly } }
-
-        context "and action is :list" do
-          let(:action) do
-            { scope: :admin, action: :list, subject: :assembly }
-          end
-
-          it { is_expected.to eq(true) }
+      context "and action is :export" do
+        let(:action) do
+          { scope: :admin, action: :export, subject: :assembly }
         end
 
-        context "and action is :export" do
-          let(:action) do
-            { scope: :admin, action: :export, subject: :assembly }
-          end
-
-          it { is_expected.to eq(true) }
-        end
-
-        context "and action is :copy" do
-          let(:action) do
-            { scope: :admin, action: :copy, subject: :assembly }
-          end
-
-          it { is_expected.to eq(true) }
-        end
+        it { is_expected.to eq(false) }
       end
 
-      context "when assembly is a child assembly" do
-        let(:context) { { assembly: child_assembly } }
-
-        context "and action is :list" do
-          let(:action) do
-            { scope: :admin, action: :list, subject: :assembly }
-          end
-
-          it { is_expected.to eq(true) }
+      context "and action is :copy" do
+        let(:action) do
+          { scope: :admin, action: :copy, subject: :assembly }
         end
 
-        context "and action is :export" do
-          let(:action) do
-            { scope: :admin, action: :export, subject: :assembly }
-          end
+        it { is_expected.to eq(false) }
+      end
+    end
 
-          it { is_expected.to eq(true) }
+    context "when assembly is a mother assembly" do
+      let(:context) { { assembly: mother_assembly } }
+
+      context "and action is :list" do
+        let(:action) do
+          { scope: :admin, action: :list, subject: :assembly }
         end
 
-        context "and action is :copy" do
-          let(:action) do
-            { scope: :admin, action: :copy, subject: :assembly }
-          end
+        it { is_expected.to eq(true) }
+      end
 
-          it { is_expected.to eq(true) }
+      context "and action is :export" do
+        let(:action) do
+          { scope: :admin, action: :export, subject: :assembly }
         end
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "and action is :copy" do
+        let(:action) do
+          { scope: :admin, action: :copy, subject: :assembly }
+        end
+
+        it { is_expected.to eq(true) }
+      end
+    end
+
+    context "when assembly is a child assembly" do
+      let(:context) { { assembly: child_assembly } }
+
+      context "and action is :list" do
+        let(:action) do
+          { scope: :admin, action: :list, subject: :assembly }
+        end
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "and action is :export" do
+        let(:action) do
+          { scope: :admin, action: :export, subject: :assembly }
+        end
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "and action is :copy" do
+        let(:action) do
+          { scope: :admin, action: :copy, subject: :assembly }
+        end
+
+        it { is_expected.to eq(true) }
       end
     end
   end

--- a/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
+++ b/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
@@ -272,7 +272,7 @@ describe Decidim::Assemblies::Permissions do
     it_behaves_like(
       "access for roles",
       org_admin: true,
-      admin: false,
+      admin: true,
       collaborator: false,
       moderator: false,
       valuator: false
@@ -363,7 +363,7 @@ describe Decidim::Assemblies::Permissions do
           { scope: :admin, action: :create, subject: :assembly }
         end
 
-        it { is_expected.to eq false }
+        it { is_expected.to eq true }
       end
 
       shared_examples "allows any action on subject" do |action_subject|
@@ -526,7 +526,7 @@ describe Decidim::Assemblies::Permissions do
           { scope: :admin, action: :list, subject: :assembly }
         end
 
-        it { is_expected.to eq(false) }
+        it { is_expected.to eq(true) }
       end
     end
   end

--- a/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
+++ b/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
@@ -279,6 +279,36 @@ describe Decidim::Assemblies::Permissions do
     )
   end
 
+  context "when exporting an assembly" do
+    let(:action) do
+      { scope: :admin, action: :export, subject: :assembly }
+    end
+
+    it_behaves_like(
+      "access for roles",
+      org_admin: true,
+      admin: false,
+      collaborator: false,
+      moderator: false,
+      valuator: false
+    )
+  end
+
+  context "when copying an assembly" do
+    let(:action) do
+      { scope: :admin, action: :copy, subject: :assembly }
+    end
+
+    it_behaves_like(
+      "access for roles",
+      org_admin: true,
+      admin: false,
+      collaborator: false,
+      moderator: false,
+      valuator: false
+    )
+  end
+
   context "when reading a assemblies settings" do
     let(:action) do
       { scope: :admin, action: :read, subject: :assemblies_setting }
@@ -527,6 +557,96 @@ describe Decidim::Assemblies::Permissions do
         end
 
         it { is_expected.to eq(true) }
+      end
+    end
+
+    describe "actions by assemblies types when user is an admin assembly" do
+      let!(:user) { create :assembly_admin, assembly: mother_assembly }
+      let(:mother_assembly) { create :assembly, parent: assembly, organization: organization, hashtag: "mother" }
+      let(:child_assembly) { create :assembly, parent: mother_assembly, organization: organization, hashtag: "child" }
+
+      context "when assembly is a grandmother assembly" do
+        let(:context) { { assembly: assembly } }
+
+        context "and action is :list" do
+          let(:action) do
+            { scope: :admin, action: :list, subject: :assembly }
+          end
+
+          it { is_expected.to eq(true) }
+        end
+
+        context "and action is :export" do
+          let(:action) do
+            { scope: :admin, action: :export, subject: :assembly }
+          end
+
+          it { is_expected.to eq(false) }
+        end
+
+        context "and action is :copy" do
+          let(:action) do
+            { scope: :admin, action: :copy, subject: :assembly }
+          end
+
+          it { is_expected.to eq(false) }
+        end
+      end
+
+      context "when assembly is a mother assembly" do
+        let(:context) { { assembly: mother_assembly } }
+
+        context "and action is :list" do
+          let(:action) do
+            { scope: :admin, action: :list, subject: :assembly }
+          end
+
+          it { is_expected.to eq(true) }
+        end
+
+        context "and action is :export" do
+          let(:action) do
+            { scope: :admin, action: :export, subject: :assembly }
+          end
+
+          it { is_expected.to eq(true) }
+        end
+
+        context "and action is :copy" do
+          let(:action) do
+            { scope: :admin, action: :copy, subject: :assembly }
+          end
+
+          it { is_expected.to eq(true) }
+        end
+      end
+
+      context "when assembly is a child assembly" do
+        let(:context) { { assembly: child_assembly } }
+
+        context "and action is :list" do
+          let(:action) do
+            { scope: :admin, action: :list, subject: :assembly }
+          end
+
+          it { is_expected.to eq(true) }
+        end
+
+        context "and action is :export" do
+          let(:action) do
+            { scope: :admin, action: :export, subject: :assembly }
+          end
+
+          it { is_expected.to eq(true) }
+        end
+
+        context "and action is :copy" do
+          let(:action) do
+            { scope: :admin, action: :copy, subject: :assembly }
+          end
+
+          it { is_expected.to eq(true) }
+        end
       end
     end
   end

--- a/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
+++ b/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
@@ -648,6 +648,14 @@ describe Decidim::Assemblies::Permissions do
 
         it { is_expected.to eq(true) }
       end
+
+      context "and action is :read the current assembly" do
+        let(:action) do
+          { scope: :admin, action: :read, subject: :assembly }
+        end
+
+        it { is_expected.to eq(true) }
+      end
     end
   end
 end

--- a/decidim-assemblies/spec/shared/assembly_admin_manage_assembly_components_examples.rb
+++ b/decidim-assemblies/spec/shared/assembly_admin_manage_assembly_components_examples.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+shared_examples "assembly admin manage assembly components" do
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  describe "add a component" do
+    before do
+      visit decidim_admin_assemblies.components_path(assembly)
+
+      find("button[data-toggle=add-component-dropdown]").click
+
+      within "#add-component-dropdown" do
+        find(".dummy").click
+      end
+
+      within ".new_component" do
+        fill_in_i18n(
+          :component_name,
+          "#component-name-tabs",
+          en: "My component",
+          ca: "La meva funcionalitat",
+          es: "Mi funcionalitat"
+        )
+
+        within ".global-settings" do
+          fill_in_i18n_editor(
+            :component_settings_dummy_global_translatable_text,
+            "#global-settings-dummy_global_translatable_text-tabs",
+            en: "Dummy Text"
+          )
+          all("input[type=checkbox]").last.click
+        end
+
+        within ".default-step-settings" do
+          fill_in_i18n_editor(
+            :component_default_step_settings_dummy_step_translatable_text,
+            "#default-step-settings-dummy_step_translatable_text-tabs",
+            en: "Dummy Text for Step"
+          )
+          all("input[type=checkbox]").first.click
+        end
+
+        click_button "Add component"
+      end
+    end
+
+    it "is successfully created" do
+      expect(page).to have_admin_callout("successfully")
+      expect(page).to have_content("My component")
+    end
+
+    context "and then edit it" do
+      before do
+        within find("tr", text: "My component") do
+          click_link "Configure"
+        end
+      end
+
+      it "successfully displays initial values in the form" do
+        within ".global-settings" do
+          expect(all("input[type=checkbox]").last).to be_checked
+        end
+
+        within ".default-step-settings" do
+          expect(all("input[type=checkbox]").first).to be_checked
+        end
+      end
+
+      it "successfully edits it" do
+        click_button "Update"
+
+        expect(page).to have_admin_callout("successfully")
+      end
+    end
+  end
+
+  describe "edit a component" do
+    let(:component_name) do
+      {
+        en: "My component",
+        ca: "La meva funcionalitat",
+        es: "Mi funcionalitat"
+      }
+    end
+
+    let!(:component) do
+      create(:component, name: component_name, participatory_space: assembly)
+    end
+
+    before do
+      visit decidim_admin_assemblies.components_path(assembly)
+    end
+
+    it "updates the component" do
+      within ".component-#{component.id}" do
+        click_link "Configure"
+      end
+
+      within ".edit_component" do
+        fill_in_i18n(
+          :component_name,
+          "#component-name-tabs",
+          en: "My updated component",
+          ca: "La meva funcionalitat actualitzada",
+          es: "Mi funcionalidad actualizada"
+        )
+
+        within ".global-settings" do
+          all("input[type=checkbox]").last.click
+        end
+
+        within ".default-step-settings" do
+          all("input[type=checkbox]").first.click
+        end
+
+        click_button "Update"
+      end
+
+      expect(page).to have_admin_callout("successfully")
+      expect(page).to have_content("My updated component")
+
+      within find("tr", text: "My updated component") do
+        click_link "Configure"
+      end
+
+      within ".global-settings" do
+        expect(all("input[type=checkbox]").last).to be_checked
+      end
+
+      within ".default-step-settings" do
+        expect(all("input[type=checkbox]").first).to be_checked
+      end
+    end
+  end
+
+  describe "remove a component" do
+    let(:component_name) do
+      {
+        en: "My component",
+        ca: "La meva funcionalitat",
+        es: "Mi funcionalitat"
+      }
+    end
+
+    let!(:component) do
+      create(:component, name: component_name, participatory_space: assembly)
+    end
+
+    before do
+      visit decidim_admin_assemblies.components_path(assembly)
+    end
+
+    it "removes the component" do
+      within ".component-#{component.id}" do
+        click_link "Delete"
+      end
+
+      expect(page).to have_no_content("My component")
+    end
+  end
+
+  describe "publish and unpublish a component" do
+    let!(:component) do
+      create(:component, participatory_space: assembly, published_at: published_at)
+    end
+
+    let(:published_at) { nil }
+
+    before do
+      visit decidim_admin_assemblies.components_path(assembly)
+    end
+
+    context "when the component is unpublished" do
+      it "publishes the component" do
+        within ".component-#{component.id}" do
+          click_link "Publish"
+        end
+
+        within ".component-#{component.id}" do
+          expect(page).to have_css(".action-icon--unpublish")
+        end
+      end
+
+      it "notifies its followers" do
+        follower = create(:user, organization: assembly.organization)
+        create(:follow, followable: assembly, user: follower)
+
+        within ".component-#{component.id}" do
+          click_link "Publish"
+        end
+
+        expect(enqueued_jobs.last[:args]).to include("decidim.events.components.component_published")
+      end
+    end
+
+    context "when the component is published" do
+      let(:published_at) { Time.current }
+
+      it "unpublishes the component" do
+        within ".component-#{component.id}" do
+          click_link "Unpublish"
+        end
+
+        within ".component-#{component.id}" do
+          expect(page).to have_css(".action-icon--publish")
+        end
+      end
+    end
+  end
+
+  def participatory_space
+    assembly
+  end
+
+  def participatory_space_components_path(participatory_space)
+    decidim_admin_assemblies.components_path(participatory_space)
+  end
+end

--- a/decidim-assemblies/spec/system/admin/assembly_admin_accesses_admin_sections_spec.rb
+++ b/decidim-assemblies/spec/system/admin/assembly_admin_accesses_admin_sections_spec.rb
@@ -8,23 +8,55 @@ describe "Assembly admin accesses admin sections", type: :system do
   before do
     switch_to_host(organization.host)
     login_as user, scope: :user
-    visit decidim_admin_assemblies.assemblies_path
-
-    click_link translated(assembly.title)
   end
 
-  it "can access all sections" do
-    within ".secondary-nav" do
-      expect(page).to have_content("Info")
-      expect(page).to have_content("Components")
-      expect(page).to have_content("Categories")
-      expect(page).to have_content("Attachments")
-      expect(page).to have_content("Folders")
-      expect(page).to have_content("Files")
-      expect(page).to have_content("Members")
-      expect(page).to have_content("Assembly admins")
-      expect(page).to have_content("Private users")
-      expect(page).to have_content("Moderations")
+  context "when is a mother assembly" do
+    it "can access all sections" do
+      visit decidim_admin_assemblies.assemblies_path
+      click_link translated(assembly.title)
+
+      within ".secondary-nav" do
+        expect(page).to have_content("Info")
+        expect(page).to have_content("Components")
+        expect(page).to have_content("Categories")
+        expect(page).to have_content("Attachments")
+        expect(page).to have_content("Folders")
+        expect(page).to have_content("Files")
+        expect(page).to have_content("Members")
+        expect(page).to have_content("Assembly admins")
+        expect(page).to have_content("Private users")
+        expect(page).to have_content("Moderations")
+      end
     end
+  end
+
+  context "when is a child assembly" do
+    let!(:child_assembly) { create :assembly, parent: assembly, organization: organization, hashtag: "child" }
+
+    before do
+      visit decidim_admin_assemblies.assemblies_path
+      within find("tr", text: translated(assembly.title)) do
+        click_link "Assemblies"
+      end
+
+      click_link translated(child_assembly.title)
+    end
+
+    it "can access all sections" do
+      within ".secondary-nav" do
+        expect(page).to have_content("Info")
+        expect(page).to have_content("Components")
+        expect(page).to have_content("Categories")
+        expect(page).to have_content("Attachments")
+        expect(page).to have_content("Folders")
+        expect(page).to have_content("Files")
+        expect(page).to have_content("Members")
+        expect(page).to have_content("Assembly admins")
+        expect(page).to have_content("Private users")
+        expect(page).to have_content("Moderations")
+      end
+    end
+
+    it_behaves_like "assembly admin manage assembly components"
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Backport "Allow assembly admins administer children assemblie" to release/0.26-stable

#### :pushpin: Related Issues

- Related to 
- https://github.com/decidim/decidim/pull/8773
-  https://github.com/decidim/decidim/pull/8955

:hearts: Thank you!
