### PR TITLE
Fix show a group conversation with users whitout avatar

### DIFF
--- a/decidim-core/app/cells/decidim/user_conversation/messages.erb
+++ b/decidim-core/app/cells/decidim/user_conversation/messages.erb
@@ -1,6 +1,8 @@
 <div class="conversation-chat<%= " conversation-chat--offset" if sender_is_user?(sender) %>">
-  <%= link_to sender.personal_url do %>
-    <%= image_tag sender.attached_uploader(:avatar).url(host: current_organization.host), alt: t("decidim.author.avatar", name: decidim_sanitize(sender.name)) %>
+  <% if sender.avatar.present? %>
+    <%= link_to sender.personal_url do %>
+      <%= image_tag sender.attached_uploader(:avatar).url(host: current_organization.host), alt: t("decidim.author.avatar", name: decidim_sanitize(sender.name)) %>
+    <% end %>
   <% end %>
   <div>
     <% messages.each do |message| %>


### PR DESCRIPTION
#### :tophat: What? Why?
In conversations, when there is a group and the member doesn't have an avatar, this is not controlled and returns an error.

#### Testing
1. Go to user profile > Conversations
2. Select any group
3. Create a new conversation with two users.
4. All works!

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
