### PR TITLE
Backport "Fix permissions to create meeting when private space" to v0.25

### DIFF
--- a/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
@@ -70,8 +70,6 @@ module Decidim
       end
 
       def can_create_meetings?
-        return false if user.admin?
-
         component_settings&.creation_enabled_for_participants? && public_space_or_member?
       end
 
@@ -81,10 +79,11 @@ module Decidim
         participatory_space.private_space? ? space_member?(participatory_space, user) : true
       end
 
+      # Neither platform admins, nor space admins should be able to create meetings from the public side.
       def space_member?(participatory_space, user)
         return false unless user
 
-        participatory_space.admins.exists?(user.id) || participatory_space.participatory_space_private_users.exists?(decidim_user_id: user.id)
+        participatory_space.participatory_space_private_users.exists?(decidim_user_id: user.id)
       end
 
       def can_update_meeting?

--- a/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
@@ -70,7 +70,19 @@ module Decidim
       end
 
       def can_create_meetings?
-        component_settings&.creation_enabled_for_participants?
+        component_settings&.creation_enabled_for_participants? && public_space_or_member?
+      end
+
+      def public_space_or_member?
+        participatory_space = context[:current_component].participatory_space
+
+        participatory_space.private_space? ? space_member?(participatory_space, user) : true
+      end
+
+      def space_member?(participatory_space, user)
+        return false unless user
+
+        participatory_space.admins.exists?(user.id) || participatory_space.participatory_space_private_users.exists?(decidim_user_id: user.id)
       end
 
       def can_update_meeting?

--- a/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
@@ -70,6 +70,8 @@ module Decidim
       end
 
       def can_create_meetings?
+        return false if user.admin?
+
         component_settings&.creation_enabled_for_participants? && public_space_or_member?
       end
 

--- a/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
+++ b/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
@@ -204,6 +204,12 @@ describe Decidim::Meetings::Permissions do
         it { is_expected.to be false }
       end
 
+      context "when user is admin" do
+        let(:user) { admin_user }
+
+        it { is_expected.to be false }
+      end
+
       context "when user is a space admin" do
         before do
           create(:participatory_process_user_role, user: user, participatory_process: participatory_space)

--- a/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
+++ b/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
@@ -204,10 +204,20 @@ describe Decidim::Meetings::Permissions do
         it { is_expected.to be false }
       end
 
-      context "when user is admin" do
+      context "when user is admin and not a member" do
         let(:user) { admin_user }
 
         it { is_expected.to be false }
+      end
+
+      context "when user is admin but is a member" do
+        let(:user) { admin_user }
+
+        before do
+          create(:participatory_space_private_user, user: user, privatable_to: participatory_space)
+        end
+
+        it { is_expected.to be true }
       end
 
       context "when user is a space admin" do
@@ -215,7 +225,7 @@ describe Decidim::Meetings::Permissions do
           create(:participatory_process_user_role, user: user, participatory_process: participatory_space)
         end
 
-        it { is_expected.to be true }
+        it { is_expected.to be false }
       end
 
       context "when user is a space private participant" do

--- a/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
+++ b/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
@@ -5,8 +5,9 @@ require "spec_helper"
 describe Decidim::Meetings::Permissions do
   subject { described_class.new(user, permission_action, context).permissions.allowed? }
 
-  let(:user) { create :user, organization: meeting_component.organization }
-  let(:admin_user) { create :user, :admin, organization: meeting_component.organization }
+  let(:participatory_space) { create(:participatory_process, :with_steps) }
+  let(:user) { create :user, organization: participatory_space.organization }
+  let(:admin_user) { create :user, :admin, organization: participatory_space.organization }
   let(:context) do
     {
       current_component: meeting_component,
@@ -18,7 +19,7 @@ describe Decidim::Meetings::Permissions do
   let(:component_settings) do
     double(creation_enabled_for_participants?: true)
   end
-  let(:meeting_component) { create :meeting_component }
+  let(:meeting_component) { create :meeting_component, participatory_space: participatory_space }
   let(:meeting) { create :meeting, component: meeting_component }
   let(:permission_action) { Decidim::PermissionAction.new(action) }
   let(:poll) { create :poll, meeting: meeting }
@@ -189,8 +190,35 @@ describe Decidim::Meetings::Permissions do
       { scope: :public, action: :create, subject: :meeting }
     end
 
-    context "when setting is enabled" do
-      it { is_expected.to eq true }
+    context "when space is public and setting is enabled" do
+      it { is_expected.to be true }
+    end
+
+    context "when space is private and setting is enabled" do
+      let(:participatory_space) { create(:participatory_process, :with_steps, private_space: true) }
+      let(:component_settings) do
+        double(creation_enabled_for_participants?: true)
+      end
+
+      context "when user is not a member" do
+        it { is_expected.to be false }
+      end
+
+      context "when user is a space admin" do
+        before do
+          create(:participatory_process_user_role, user: user, participatory_process: participatory_space)
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context "when user is a space private participant" do
+        before do
+          create(:participatory_space_private_user, user: user, privatable_to: participatory_space)
+        end
+
+        it { is_expected.to be true }
+      end
     end
 
     context "when setting is disabled" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR backports [Fix permissions to create meeting when private space](https://github.com/decidim/decidim/pull/9384#)
 to `release/v0.25-stable`.