### PR TITLE
Backport 'Fix usages of reorder and paginate' to v0.25

### DIFF
--- a/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
@@ -28,7 +28,7 @@ module Decidim
       def projects
         return @projects if @projects
 
-        @projects = reorder(search.result)
+        @projects = reorder(search.results)
         @projects = @projects.page(params[:page]).per(current_component.settings.projects_per_page)
       end
 

--- a/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
@@ -28,8 +28,8 @@ module Decidim
       def projects
         return @projects if @projects
 
-        @projects = search.results.page(params[:page]).per(current_component.settings.projects_per_page)
-        @projects = reorder(@projects)
+        @projects = reorder(search.result)
+        @projects = @projects.page(params[:page]).per(current_component.settings.projects_per_page)
       end
 
       def project

--- a/decidim-budgets/spec/system/sorting_projects_spec.rb
+++ b/decidim-budgets/spec/system/sorting_projects_spec.rb
@@ -93,6 +93,29 @@ describe "Sorting projects", type: :system do
         expect(page).to have_selector("#projects .budget-list .budget-list__item:first-child", text: translated(project2.title))
         expect(page).to have_selector("#projects .budget-list .budget-list__item:last-child", text: translated(project1.title))
       end
+
+      it "automatically sorts by votes and respect the pagination" do
+        component.update!(settings: { projects_per_page: 1 })
+
+        visit_budget
+
+        within "#projects li.is-dropdown-submenu-parent a" do
+          expect(page).to have_content("Most voted")
+        end
+
+        # project2 on first page
+        expect(page).to have_content(translated(project2.title))
+        expect(page).not_to have_content(translated(project1.title))
+
+        within "#projects [data-pagination]" do
+          expect(page).to have_content("2")
+          page.find("a", text: "2").click
+        end
+
+        # project1 on second page
+        expect(page).not_to have_content(translated(project2.title))
+        expect(page).to have_content(translated(project1.title))
+      end
     end
   end
 

--- a/decidim-budgets/spec/system/sorting_projects_spec.rb
+++ b/decidim-budgets/spec/system/sorting_projects_spec.rb
@@ -107,7 +107,7 @@ describe "Sorting projects", type: :system do
         expect(page).to have_content(translated(project2.title))
         expect(page).not_to have_content(translated(project1.title))
 
-        within "#projects [data-pagination]" do
+        within "#projects .pagination" do
           expect(page).to have_content("2")
           page.find("a", text: "2").click
         end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -255,7 +255,7 @@ module Decidim
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Core::Engine.root}/app/views") # for partials
       end
 
-      initializer "doorkeeper" do
+      initializer "doorkeeper", before: "doorkeeper.params.filter" do
         Doorkeeper.configure do
           orm :active_record
 

--- a/decidim-elections/app/controllers/decidim/elections/elections_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/elections_controller.rb
@@ -57,8 +57,8 @@ module Decidim
       end
 
       def paginated_elections
-        @paginated_elections ||= paginate(search.results.published)
-        @paginated_elections = reorder(@paginated_elections)
+        @paginated_elections ||= reorder(search.result.published)
+        @paginated_elections = paginate(@paginated_elections)
       end
 
       def scheduled_elections

--- a/decidim-elections/app/controllers/decidim/elections/elections_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/elections_controller.rb
@@ -57,7 +57,7 @@ module Decidim
       end
 
       def paginated_elections
-        @paginated_elections ||= reorder(search.result.published)
+        @paginated_elections ||= reorder(search.results.published)
         @paginated_elections = paginate(@paginated_elections)
       end
 

--- a/decidim-elections/app/controllers/decidim/votings/votings_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/votings_controller.rb
@@ -127,8 +127,8 @@ module Decidim
       end
 
       def paginated_votings
-        @paginated_votings ||= paginate(search.results.published)
-        @paginated_votings = reorder(@paginated_votings)
+        @paginated_votings ||= reorder(search.result.published)
+        @paginated_votings = paginate(@paginated_votings)
       end
 
       def promoted_votings

--- a/decidim-elections/app/controllers/decidim/votings/votings_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/votings_controller.rb
@@ -127,7 +127,7 @@ module Decidim
       end
 
       def paginated_votings
-        @paginated_votings ||= reorder(search.result.published)
+        @paginated_votings ||= reorder(search.results.published)
         @paginated_votings = paginate(@paginated_votings)
       end
 

--- a/decidim-proposals/app/controllers/decidim/proposals/collaborative_drafts_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/collaborative_drafts_controller.rb
@@ -30,8 +30,8 @@ module Decidim
                                 .includes(:category)
                                 .includes(:scope)
 
-        @collaborative_drafts = paginate(@collaborative_drafts)
         @collaborative_drafts = reorder(@collaborative_drafts)
+        @collaborative_drafts = paginate(@collaborative_drafts)
       end
 
       def show

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -52,8 +52,8 @@ module Decidim
                              else
                                []
                              end
-          @proposals = paginate(@proposals)
           @proposals = reorder(@proposals)
+          @proposals = paginate(@proposals)
         end
       end
 

--- a/decidim-sortitions/app/controllers/decidim/sortitions/sortitions_controller.rb
+++ b/decidim-sortitions/app/controllers/decidim/sortitions/sortitions_controller.rb
@@ -19,8 +19,8 @@ module Decidim
                       .includes(:author)
                       .includes(:category)
 
-        @sortitions = paginate(@sortitions)
         @sortitions = reorder(@sortitions)
+        @sortitions = paginate(@sortitions)
       end
 
       private


### PR DESCRIPTION
#### :tophat: What? Why?
Backport https://github.com/decidim/decidim/pull/9926 to v0.25

EXTRA: backport doorkeeper initialization https://github.com/decidim/decidim/pull/9785

:hearts: Thank you!
