### PR TITLE
Backport "Fix filter when moderations are hidden" to release/0.26-stable

### DIFF
--- a/decidim-admin/app/controllers/concerns/decidim/moderations/admin/filterable.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/moderations/admin/filterable.rb
@@ -47,6 +47,10 @@ module Decidim
           def reportable_types
             collection.pluck(:decidim_reportable_type).uniq.sort
           end
+
+          def extra_allowed_params
+            [:hidden]
+          end
         end
       end
     end

--- a/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
@@ -23,19 +23,10 @@ describe "Admin manages global moderations", type: :system do
     login_as user, scope: :user
   end
 
-  it_behaves_like "manage moderations" do
-    let(:moderations_link_text) { "Global moderations" }
-  end
-
-  it_behaves_like "sorted moderations" do
-    let!(:reportables) { create_list(:dummy_resource, 17, component: current_component) }
-    let(:moderations_link_text) { "Global moderations" }
-  end
-
   context "when on hidden moderations path" do
     let!(:hidden_moderations) do
       moderation = create(:moderation, reportable: reportables.last, report_count: 3, reported_content: reportables.last.reported_searchable_content_text, hidden_at: Time.current)
-      create_list(:report, 3, moderation:, reason: :spam)
+      create_list(:report, 3, moderation: moderation, reason: :spam)
       [moderation]
     end
     let!(:hidden_moderation) { hidden_moderations.first }

--- a/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
@@ -26,4 +26,31 @@ describe "Admin manages global moderations", type: :system do
   it_behaves_like "manage moderations" do
     let(:moderations_link_text) { "Global moderations" }
   end
+
+  it_behaves_like "sorted moderations" do
+    let!(:reportables) { create_list(:dummy_resource, 17, component: current_component) }
+    let(:moderations_link_text) { "Global moderations" }
+  end
+
+  context "when on hidden moderations path" do
+    let!(:hidden_moderations) do
+      moderation = create(:moderation, reportable: reportables.last, report_count: 3, reported_content: reportables.last.reported_searchable_content_text, hidden_at: Time.current)
+      create_list(:report, 3, moderation:, reason: :spam)
+      [moderation]
+    end
+    let!(:hidden_moderation) { hidden_moderations.first }
+
+    before do
+      visit decidim_admin.moderations_path(hidden: true)
+    end
+
+    it "can be filtering by id" do
+      search = hidden_moderation.reportable.id
+      within ".filters__section" do
+        fill_in("Search Moderation by reportable id or content.", with: search)
+        find(:xpath, "//button[@type='submit']").click
+      end
+      expect(page).to have_selector("tbody tr", count: 1)
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Backport "Fix filter when moderations are hidden" to release/0.26-stable

#### :pushpin: Related Issues

- Related to https://github.com/decidim/decidim/pull/11588


:hearts: Thank you!
