### PR TITLE
Backport "Add alert when publish a survey with answers" to release/0.27-stable

### DIFF
--- a/decidim-admin/app/views/decidim/admin/components/_actions.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/_actions.html.erb
@@ -1,0 +1,43 @@
+<% if component.manifest.admin_engine %>
+  <%= icon_link_to "pencil", manage_component_path(component), t("actions.manage", scope: "decidim.admin"), class: "action-icon--manage" %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>
+
+<% if allowed_to?(:update, :component, component: component) %>
+  <% if component.published? %>
+    <%= icon_link_to "x", url_for(action: :unpublish, id: component, controller: "components"), t("actions.unpublish", scope: "decidim.admin"), class: "action-icon--unpublish", method: :put %>
+  <% else %>
+    <%= icon_link_to "check", url_for(action: :publish, id: component, controller: "components"), t("actions.publish", scope: "decidim.admin"), class: "action-icon--publish", method: :put %>
+  <% end %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>
+
+<% if allowed_to? :update, :component, component: component %>
+  <%= icon_link_to "cog", url_for(action: :edit, id: component, controller: "components"), t("actions.configure", scope: "decidim.admin"), class: "action-icon--configure" %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>
+
+<% if allowed_to? :update, :component, component: component %>
+  <% if component.manifest.actions.empty? %>
+    <%= icon "key", class: "action-icon action-icon--disabled" %>
+  <% else %>
+    <%= icon_link_to "key", url_for(action: :edit, component_id: component, controller: "component_permissions"), t("actions.permissions", scope: "decidim.admin"), class: "action-icon--permissions" %>
+  <% end %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>
+
+<% if allowed_to? :share, :component, component: component %>
+  <%= icon_link_to "share", url_for(action: :share, id: component, controller: "components"), t("actions.share", scope: "decidim.admin"), class: "action-icon--share", target: "_blank" %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>
+
+<% if allowed_to? :destroy, :component, component: component %>
+  <%= icon_link_to "circle-x", url_for(action: :destroy, id: component, controller: "components"), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>

--- a/decidim-admin/app/views/decidim/admin/components/_component.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/_component.html.erb
@@ -10,48 +10,10 @@
     </td>
     <%= td_resource_scope_for(component.scope) %>
     <td class="table-list__actions">
-      <% if component.manifest.admin_engine %>
-        <%= icon_link_to "pencil", manage_component_path(component), t("actions.manage", scope: "decidim.admin"), class: "action-icon--manage" %>
+      <% if lookup_context.find_all("decidim/#{component.manifest_name}/admin/component/_actions").any? %>
+        <%= render partial: "decidim/#{component.manifest_name}/admin/component/actions", locals: { component: component } %>
       <% else %>
-        <span class="action-space icon"></span>
-      <% end %>
-
-      <% if allowed_to?(:update, :component, component: component) %>
-        <% if component.published? %>
-          <%= icon_link_to "x", url_for(action: :unpublish, id: component, controller: "components"), t("actions.unpublish", scope: "decidim.admin"), class: "action-icon--unpublish", method: :put %>
-        <% else %>
-          <%= icon_link_to "check", url_for(action: :publish, id: component, controller: "components"), t("actions.publish", scope: "decidim.admin"), class: "action-icon--publish", method: :put %>
-        <% end %>
-      <% else %>
-        <span class="action-space icon"></span>
-      <% end %>
-
-      <% if allowed_to? :update, :component, component: component %>
-        <%= icon_link_to "cog", url_for(action: :edit, id: component, controller: "components"), t("actions.configure", scope: "decidim.admin"), class: "action-icon--configure" %>
-      <% else %>
-        <span class="action-space icon"></span>
-      <% end %>
-
-      <% if allowed_to? :update, :component, component: component %>
-        <% if component.manifest.actions.empty? %>
-          <%= icon "key", class: "action-icon action-icon--disabled" %>
-        <% else %>
-          <%= icon_link_to "key", url_for(action: :edit, component_id: component, controller: "component_permissions"), t("actions.permissions", scope: "decidim.admin"), class: "action-icon--permissions" %>
-        <% end %>
-      <% else %>
-        <span class="action-space icon"></span>
-      <% end %>
-
-      <% if allowed_to? :share, :component, component: component %>
-        <%= icon_link_to "share", url_for(action: :share, id: component, controller: "components"), t("actions.share", scope: "decidim.admin"), class: "action-icon--share", target: "_blank" %>
-      <% else %>
-        <span class="action-space icon"></span>
-      <% end %>
-
-      <% if allowed_to? :destroy, :component, component: component %>
-        <%= icon_link_to "circle-x", url_for(action: :destroy, id: component, controller: "components"), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete %>
-      <% else %>
-        <span class="action-space icon"></span>
+        <%= render partial: "actions", locals: { component: component } %>
       <% end %>
     </td>
   </tr>

--- a/decidim-surveys/app/views/decidim/surveys/admin/component/_actions.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/component/_actions.html.erb
@@ -1,0 +1,43 @@
+<% if component.manifest.admin_engine %>
+  <%= icon_link_to "pencil", manage_component_path(component), t("actions.manage", scope: "decidim.admin"), class: "action-icon--manage" %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>
+
+<% if allowed_to?(:update, :component, component: component) %>
+  <% if component.published? %>
+    <%= icon_link_to "x", url_for(action: :unpublish, id: component, controller: "components"), t("actions.unpublish", scope: "decidim.admin"), class: "action-icon--unpublish", method: :put %>
+  <% else %>
+    <%= icon_link_to "check", url_for(action: :publish, id: component, controller: "components"), t("actions.publish", scope: "decidim.admin"), class: "action-icon--publish", method: :put, data: { confirm: t(".answers_alert") } %>
+  <% end %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>
+
+<% if allowed_to? :update, :component, component: component %>
+  <%= icon_link_to "cog", url_for(action: :edit, id: component, controller: "components"), t("actions.configure", scope: "decidim.admin"), class: "action-icon--configure" %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>
+
+<% if allowed_to? :update, :component, component: component %>
+  <% if component.manifest.actions.empty? %>
+    <%= icon "key", class: "action-icon action-icon--disabled" %>
+  <% else %>
+    <%= icon_link_to "key", url_for(action: :edit, component_id: component, controller: "component_permissions"), t("actions.permissions", scope: "decidim.admin"), class: "action-icon--permissions" %>
+  <% end %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>
+
+<% if allowed_to? :share, :component, component: component %>
+  <%= icon_link_to "share", url_for(action: :share, id: component, controller: "components"), t("actions.share", scope: "decidim.admin"), class: "action-icon--share", target: "_blank" %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>
+
+<% if allowed_to? :destroy, :component, component: component %>
+  <%= icon_link_to "circle-x", url_for(action: :destroy, id: component, controller: "components"), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -54,6 +54,9 @@ en:
       answers_count: Answers
     surveys:
       admin:
+        component:
+          actions:
+            answers_alert: If you publish the component, all results will be removed.
         exports:
           survey_user_answers: Survey participant answers
         surveys:

--- a/decidim-surveys/spec/system/admin_manages_surveys_spec.rb
+++ b/decidim-surveys/spec/system/admin_manages_surveys_spec.rb
@@ -75,6 +75,13 @@ describe "Admin manages surveys", type: :system do
 
       context "when publishing the survey" do
         let(:clean_after_publish) { true }
+        let!(:participatory_process) do
+          create(:participatory_process, organization: organization)
+        end
+        let(:participatory_space_path) do
+          decidim_admin_participatory_processes.components_path(participatory_process)
+        end
+        let(:components_path) { participatory_space_path }
 
         before do
           component.update!(
@@ -82,17 +89,26 @@ describe "Admin manages surveys", type: :system do
               clean_after_publish: clean_after_publish
             }
           )
+
+          visit components_path
         end
 
         context "when clean_after_publish is set to true" do
-          it "deletes previous answers afer publishing" do
-            expect(survey.clean_after_publish?).to be true
-
-            perform_enqueued_jobs do
-              Decidim::Admin::PublishComponent.call(component, user)
+          context "when deletes previous answers afer publishing" do
+            it "show popup with an alert" do
+              find(:css, ".action-icon--publish").click
+              expect(page).to have_content("Confirm")
             end
 
-            expect(questionnaire.answers).to be_empty
+            it "deletes previous answers" do
+              expect(survey.clean_after_publish?).to be true
+
+              perform_enqueued_jobs do
+                Decidim::Admin::PublishComponent.call(component, user)
+              end
+
+              expect(questionnaire.answers).to be_empty
+            end
           end
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Backport "Add alert when publish a survey with answers" to release/0.27-stable

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/11450

:hearts: Thank you!
