### PR TITLE
Fix performance time in surveys

### DIFF
--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -305,8 +305,6 @@ en:
           error: There was a problem updating the permissions of this component.
           success: Permissions updated successfully.
       components:
-        component:
-          answers_alert: If you publish the component, all results will be removed.
         create:
           error: There was a problem creating this component.
           success: Component created successfully.

--- a/decidim-elections/lib/decidim/elections/component.rb
+++ b/decidim-elections/lib/decidim/elections/component.rb
@@ -46,7 +46,7 @@ Decidim.register_component(:elections) do |component|
 
   component.exports :feedback_form_answers do |exports|
     exports.collection do |_component, _user, resource_id|
-      Decidim::Forms::QuestionnaireUserAnswers.for(resource_id)
+      Decidim::Forms::QuestionnaireUsersAnswers.for(resource_id)
     end
 
     exports.formats %w(CSV JSON Excel FormPDF)

--- a/decidim-forms/app/controllers/decidim/forms/admin/concerns/has_questionnaire_answers.rb
+++ b/decidim-forms/app/controllers/decidim/forms/admin/concerns/has_questionnaire_answers.rb
@@ -46,7 +46,7 @@ module Decidim
               enforce_permission_to :export_response, :questionnaire_answers
 
               session_token = params[:session_token]
-              answers = QuestionnaireUserAnswers.for(questionnaire)
+              answers = QuestionnaireUsersAnswers.for(questionnaire)
 
               # i18n-tasks-use t("decidim.forms.admin.questionnaires.answers.export_response.title")
               title = t("export_response.title", scope: i18n_scope, token: session_token)

--- a/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
@@ -148,11 +148,12 @@ module Decidim
 
           # This method send confirmation email with answers to user when a questionnaire is answered.
           def send_confirmation_email
-            component = @questionnaire.questionnaire_for.component
-            answers = Decidim::Forms::QuestionnaireUserAnswers.for(@questionnaire)
-            user_answers = answers.select { |a| a.first.session_token == session_token }
+            if current_user.present?
+              component = @questionnaire.questionnaire_for.component
+              user_answers = Decidim::Forms::QuestionnaireUserAnswers.for(questionnaire, current_user)
 
-            Decidim::Surveys::ConfirmationDeliveryJob.perform_now(current_user, @questionnaire, user_answers) if component.manifest_name == "surveys" && answers.present?
+              Decidim::Surveys::ConfirmationDeliveryJob.perform_now(current_user, @questionnaire, user_answers) if component.manifest_name == "surveys" && user_answers.present?
+            end
           end
         end
       end

--- a/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
@@ -153,7 +153,7 @@ module Decidim
             component = @questionnaire.questionnaire_for.component
             user_answers = Decidim::Forms::QuestionnaireUserAnswers.for(questionnaire, current_user)
 
-            Decidim::Surveys::ConfirmationDeliveryJob.perform_now(current_user, @questionnaire, user_answers) if component.manifest_name == "surveys" && user_answers.present?
+            Decidim::Surveys::ConfirmationDeliveryJob.perform_now(current_user, questionnaire, user_answers) if component.manifest_name == "surveys" && user_answers.first.present?
           end
         end
       end

--- a/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
@@ -148,12 +148,12 @@ module Decidim
 
           # This method send confirmation email with answers to user when a questionnaire is answered.
           def send_confirmation_email
-            if current_user.present?
-              component = @questionnaire.questionnaire_for.component
-              user_answers = Decidim::Forms::QuestionnaireUserAnswers.for(questionnaire, current_user)
+            return unless current_user.present?
 
-              Decidim::Surveys::ConfirmationDeliveryJob.perform_now(current_user, @questionnaire, user_answers) if component.manifest_name == "surveys" && user_answers.present?
-            end
+            component = @questionnaire.questionnaire_for.component
+            user_answers = Decidim::Forms::QuestionnaireUserAnswers.for(questionnaire, current_user)
+
+            Decidim::Surveys::ConfirmationDeliveryJob.perform_now(current_user, @questionnaire, user_answers) if component.manifest_name == "surveys" && user_answers.present?
           end
         end
       end

--- a/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
@@ -148,7 +148,7 @@ module Decidim
 
           # This method send confirmation email with answers to user when a questionnaire is answered.
           def send_confirmation_email
-            return unless current_user.present?
+            return if current_user.blank?
 
             component = @questionnaire.questionnaire_for.component
             user_answers = Decidim::Forms::QuestionnaireUserAnswers.for(questionnaire, current_user)

--- a/decidim-forms/app/queries/decidim/forms/questionnaire_user_answers.rb
+++ b/decidim-forms/app/queries/decidim/forms/questionnaire_user_answers.rb
@@ -28,7 +28,7 @@ module Decidim
                         .joins(:question)
                         .where(questionnaire: @questionnaire, user: @user)
 
-        answers.sort_by { |answer| answer.question.position }.group_by(&:user).values
+        [answers.sort_by { |answer| answer.question.position }]
       end
     end
   end

--- a/decidim-forms/app/queries/decidim/forms/questionnaire_users_answers.rb
+++ b/decidim-forms/app/queries/decidim/forms/questionnaire_users_answers.rb
@@ -3,22 +3,19 @@
 module Decidim
   module Forms
     # A class used to collect user answers for a questionnaire
-    class QuestionnaireUserAnswers < Rectify::Query
+    class QuestionnaireUsersAnswers < Rectify::Query
       # Syntactic sugar to initialize the class and return the queried objects.
       #
       # questionnaire - a Questionnaire object
-      # user - a User object
-      def self.for(questionnaire, user)
-        new(questionnaire, user).query
+      def self.for(questionnaire)
+        new(questionnaire).query
       end
 
       # Initializes the class.
       #
-      # questionnaire - a Questionnaire object
-      # user          - a User object
-      def initialize(questionnaire, user)
+      # questionnaire = a Questionnaire object
+      def initialize(questionnaire)
         @questionnaire = questionnaire
-        @user = user
       end
 
       # Finds and group answers by user for each questionnaire's question.
@@ -26,9 +23,9 @@ module Decidim
         answers = Answer.not_separator
                         .not_title_and_description
                         .joins(:question)
-                        .where(questionnaire: @questionnaire, user: @user)
+                        .where(questionnaire: @questionnaire)
 
-        answers.sort_by { |answer| answer.question.position }.group_by(&:user).values
+        answers.sort_by { |answer| answer.question.position }.group_by { |a| a.user || a.session_token }.values
       end
     end
   end

--- a/decidim-forms/spec/queries/decidim/forms/questionnaire_users_answers_spec.rb
+++ b/decidim-forms/spec/queries/decidim/forms/questionnaire_users_answers_spec.rb
@@ -2,8 +2,8 @@
 
 require "spec_helper"
 
-describe Decidim::Forms::QuestionnaireUserAnswers do
-  subject { described_class.new(questionnaire, user_1) }
+describe Decidim::Forms::QuestionnaireUsersAnswers do
+  subject { described_class.new(questionnaire) }
 
   let!(:questionnaire) { create(:questionnaire) }
   let!(:user_1) { create(:user, organization: questionnaire.questionnaire_for.organization) }
@@ -19,9 +19,9 @@ describe Decidim::Forms::QuestionnaireUserAnswers do
   let!(:answers_user_1) { questions.map { |question| create :answer, user: user_1, questionnaire: questionnaire, question: question } }
   let!(:answers_user_2) { questions.map { |question| create :answer, user: user_2, questionnaire: questionnaire, question: question } }
 
-  it "returns the user answers only for user passed without the separators and title-and-descriptions" do
+  it "returns the user answers for each user without the separators and title-and-descriptions" do
     result = subject.query
 
-    expect(result).to contain_exactly([answers_user_1.last, answers_user_1.first])
+    expect(result).to contain_exactly([answers_user_1.last, answers_user_1.first], [answers_user_2.last, answers_user_2.first])
   end
 end

--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -76,7 +76,7 @@ Decidim.register_component(:surveys) do |component|
   component.exports :survey_user_answers do |exports|
     exports.collection do |f|
       survey = Decidim::Surveys::Survey.find_by(component: f)
-      Decidim::Forms::QuestionnaireUserAnswers.for(survey.questionnaire)
+      Decidim::Forms::QuestionnaireUsersAnswers.for(survey.questionnaire)
     end
 
     exports.formats %w(CSV JSON Excel FormPDF)


### PR DESCRIPTION
#### :tophat: What? Why?
Currently, surveys can be answered by registers users and anonymous users.

In this PR two things have been reviewed:
- The confirmations answers email job is queued, either you were a registered user or not. This sending should only be made if the user is registered.
- When the email is sent, the user answers in the query were not filtered by user and the sending time increased when there were many responses in the questionnaire. Now only the user's answers are taken.

:hearts: Thank you!
