### PR TITLE
include templatable in concern

### DIFF
--- a/decidim-forms/app/controllers/decidim/forms/admin/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/admin/concerns/has_questionnaire.rb
@@ -16,12 +16,12 @@ module Decidim
           included do
             helper Decidim::Forms::Admin::ApplicationHelper
             include Decidim::TranslatableAttributes
+            include Decidim::Templates::Admin::Concerns::Templatable
 
             helper_method :questionnaire_for, :questionnaire, :blank_question, :blank_answer_option, :blank_matrix_row,
                           :blank_display_condition, :question_types, :display_condition_types, :update_url, :public_url, :answer_options_url, :edit_questionnaire_title
 
             if defined?(Decidim::Templates::Admin::Concerns::Templatable)
-              include Decidim::Templates::Admin::Concerns::Templatable
               helper Decidim::DatalistSelectHelper
 
               def templatable_type


### PR DESCRIPTION
#### :tophat: What? Why?
In production, `defined?(Decidim::Templates::Admin::Concerns::Templatable)` is nil without include templatable concern