### PR TITLE
Backport 'Hide empty announcement block when no text is present' to v0.28-stable

### DIFF
--- a/decidim-core/app/views/decidim/shared/_component_announcement.html.erb
+++ b/decidim-core/app/views/decidim/shared/_component_announcement.html.erb
@@ -1,5 +1,5 @@
 <% announcement = translated_attribute(current_settings.announcement).presence || translated_attribute(component_settings.announcement).presence %>
-<% if announcement %>
+<% if strip_tags(announcement).present? %>
   <section class="layout-main__section">
     <%= cell("decidim/announcement", announcement, local_assigns.merge(callout_class: "editor-content")) %>
   </section>


### PR DESCRIPTION
#### :tophat: What? Why?
This backport fixes a bug where the announcement block was still being displayed even when no actual content was present.

Until version 0.28, announcements were only shown when there was real text. However, due to HTML tags being saved (e.g.,

) when the textarea had been filled and then emptied, the frontend would still render the block.
Now we strip HTML tags and whitespace from the announcement content to make sure it's truly empty before rendering it.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
