### PR TITLE
Backport 'Fix missing reportable_content_url method' to v0.29

### DIFF
--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -140,8 +140,10 @@ module Decidim
 
         if root_commentable.respond_to?(:polymorphic_resource_url)
           root_commentable.polymorphic_resource_url(url_params)
-        else
+        elsif root_commentable.respond_to?(:reported_content_url)
           root_commentable.reported_content_url(url_params)
+        else
+          "/"
         end
       end
 

--- a/decidim-conferences/lib/decidim/conferences/seeds.rb
+++ b/decidim-conferences/lib/decidim/conferences/seeds.rb
@@ -91,7 +91,7 @@ module Decidim
               short_bio: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
                 Decidim::Faker::Localized.paragraph(sentence_count: 3)
               end,
-              twitter_handle: ::Faker::Twitter.unique.screen_name,
+              twitter_handle: ::Faker::X.unique.screen_name,
               personal_url: ::Faker::Internet.url,
               published_at: Time.current,
               conference:

--- a/decidim-core/lib/decidim/core/seeds.rb
+++ b/decidim-core/lib/decidim/core/seeds.rb
@@ -106,7 +106,7 @@ module Decidim
       end
 
       def create_organization!
-        smtp_label = ENV.fetch("SMTP_FROM_LABEL", ::Faker::Twitter.unique.screen_name)
+        smtp_label = ENV.fetch("SMTP_FROM_LABEL", ::Faker::X.unique.screen_name)
         smtp_email = ENV.fetch("SMTP_FROM_EMAIL", ::Faker::Internet.email)
 
         primary_color, secondary_color, tertiary_color = [
@@ -134,7 +134,7 @@ module Decidim
             from: "#{smtp_label} <#{smtp_email}>",
             from_email: smtp_email,
             from_label: smtp_label,
-            user_name: ENV.fetch("SMTP_USERNAME", ::Faker::Twitter.unique.screen_name),
+            user_name: ENV.fetch("SMTP_USERNAME", ::Faker::X.unique.screen_name),
             encrypted_password: Decidim::AttributeEncryptor.encrypt(ENV.fetch("SMTP_PASSWORD", ::Faker::Internet.password(min_length: 8))),
             address: ENV.fetch("SMTP_ADDRESS", nil) || ENV.fetch("DECIDIM_HOST", "localhost"),
             port: ENV.fetch("SMTP_PORT", nil) || ENV.fetch("DECIDIM_SMTP_PORT", "25")
@@ -202,7 +202,7 @@ module Decidim
       def create_user_group!(user:, verified_at:)
         user_group = Decidim::UserGroup.create!(
           name: ::Faker::Company.unique.name,
-          nickname: ::Faker::Twitter.unique.screen_name,
+          nickname: ::Faker::X.unique.screen_name,
           email: ::Faker::Internet.email,
           confirmed_at: Time.current,
           extended_data: {

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -806,6 +806,30 @@ shared_examples "comments" do
           expect(page.find("#comment-#{parent.id}-replies").text).to be_blank
         end
       end
+
+      context "when admin moderates the comment" do
+        let!(:user) { create(:user, :admin, :confirmed, organization:) }
+
+        before do
+          switch_to_host(organization.host)
+          login_as user, scope: :user
+          visit resource_path
+        end
+
+        it "hides the comment" do
+          within "#comment_#{comments.first.id}" do
+            page.find("[id^='dropdown-trigger']").click
+            click_on "Report"
+          end
+
+          within "#flagModalComment#{comments.first.id}" do
+            check "Hide this content"
+            click_on "Hide"
+          end
+
+          expect(page).to have_content("This resource has been hidden.")
+        end
+      end
     end
 
     describe "arguable option" do

--- a/decidim-core/lib/decidim/seeds.rb
+++ b/decidim-core/lib/decidim/seeds.rb
@@ -21,7 +21,7 @@ module Decidim
       user = Decidim::User.find_or_initialize_by(email:)
       user.update!(
         name: ::Faker::Name.name,
-        nickname: ::Faker::Twitter.unique.screen_name,
+        nickname: ::Faker::X.unique.screen_name,
         password: "decidim123456789",
         organization:,
         confirmed_at: Time.current,

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -153,7 +153,7 @@ module Decidim
       end
 
       def random_nickname
-        "#{::Faker::Twitter.unique.screen_name}-#{SecureRandom.hex(4)}"[0, 20]
+        "#{::Faker::X.unique.screen_name}-#{SecureRandom.hex(4)}"[0, 20]
       end
 
       def random_email(suffix:)


### PR DESCRIPTION
#### :tophat: What? Why?
Backport https://github.com/decidim/decidim/pull/15105 to v0.29

:hearts: Thank you!
