### PR TITLE
Fix allow admins deleting attachments with links

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -22,6 +22,7 @@ jobs:
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      NODE_OPTIONS: '--experimental-global-webcrypto'
     services:
       postgres:
         image: postgres:14

--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -22,7 +22,6 @@ jobs:
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
-      NODE_OPTIONS: '--experimental-global-webcrypto'
     services:
       postgres:
         image: postgres:14

--- a/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
@@ -3,6 +3,7 @@
 shared_examples "manage attachments examples" do
   context "when processing attachments" do
     let!(:attachment) { create(:attachment, attached_to:, attachment_collection:) }
+    let!(:attachment_with_link) { create(:attachment, :with_link, attached_to:, attachment_collection:) }
 
     before do
       visit current_path
@@ -177,6 +178,17 @@ shared_examples "manage attachments examples" do
       expect(page).to have_admin_callout("successfully")
 
       expect(page).to have_no_content(translated(attachment.title, locale: :en))
+    end
+
+    it "can delete an attachment with a link" do
+      within "tr", text: translated(attachment_with_link.title) do
+        find("button[data-controller='dropdown']").click
+        accept_confirm { click_on "Delete" }
+      end
+
+      expect(page).to have_admin_callout("Attachment destroyed successfully")
+
+      expect(page).to have_no_content(translated(attachment_with_link.title, locale: :en))
     end
 
     it "can update an attachment" do

--- a/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
@@ -19,8 +19,10 @@ shared_examples "manage attachments examples" do
     end
 
     it "can view an attachment details" do
-      within "#attachments table" do
-        click_on "Edit"
+      within "#attachments" do
+        within "tr", text: translated(attachment.title, locale: :en) do
+          click_on "Edit"
+        end
       end
 
       expect(page).to have_css("input#attachment_title_en[value='#{translated(attachment.title, locale: :en)}']")
@@ -182,7 +184,6 @@ shared_examples "manage attachments examples" do
 
     it "can delete an attachment with a link" do
       within "tr", text: translated(attachment_with_link.title) do
-        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 

--- a/decidim-admin/spec/system/admin_manages_organization_homepage_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_homepage_spec.rb
@@ -40,6 +40,7 @@ describe "Admin manages organization homepage" do
       )
 
       click_on "Update"
+      sleep 1
       visit decidim.root_path
       expect(page).to have_content("Custom welcome text!")
     end
@@ -50,6 +51,7 @@ describe "Admin manages organization homepage" do
       dynamically_attach_file(:content_block_images_background_image, Decidim::Dev.asset("city2.jpeg"))
 
       click_on "Update"
+      sleep 1
       visit decidim.root_path
       expect(page.html).to include("city2.jpeg")
     end

--- a/decidim-conferences/lib/decidim/conferences/seeds.rb
+++ b/decidim-conferences/lib/decidim/conferences/seeds.rb
@@ -91,7 +91,7 @@ module Decidim
               short_bio: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
                 Decidim::Faker::Localized.paragraph(sentence_count: 3)
               end,
-              twitter_handle: ::Faker::Internet.unique.username(specifier: 5..15, separators: %w[_]),
+              twitter_handle: ::Faker::Internet.unique.username(specifier: 5..15, separators: %w(_)),
               personal_url: ::Faker::Internet.url,
               published_at: Time.current,
               conference:

--- a/decidim-conferences/lib/decidim/conferences/seeds.rb
+++ b/decidim-conferences/lib/decidim/conferences/seeds.rb
@@ -91,7 +91,7 @@ module Decidim
               short_bio: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
                 Decidim::Faker::Localized.paragraph(sentence_count: 3)
               end,
-              twitter_handle: ::Faker::X.unique.screen_name,
+              twitter_handle: ::Faker::Internet.unique.username(specifier: 5..15, separators: %w[_]),
               personal_url: ::Faker::Internet.url,
               published_at: Time.current,
               conference:

--- a/decidim-core/app/cells/decidim/content_blocks/cta_settings_form/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/cta_settings_form/show.erb
@@ -4,6 +4,6 @@
   <%= settings_fields.translated :text_field, :description, label: t("decidim.content_blocks.cta_settings_form.description") %>
 <% end %>
 
-<% form.fields_for :images, form.object.images do |images_fields| %>
+<% form.fields_for :images, content_block.images_container do |images_fields| %>
   <%= images_fields.upload :background_image, label: t("decidim.content_blocks.cta_settings_form.background_image") %>
 <% end %>

--- a/decidim-core/app/cells/decidim/content_blocks/hero_settings_form/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/hero_settings_form/show.erb
@@ -2,6 +2,6 @@
   <%= settings_fields.translated :text_field, :welcome_text, label: t(".welcome_text") %>
 <% end %>
 
-<% form.fields_for :images, form.object.images do |images_fields| %>
+<% form.fields_for :images, content_block.images_container do |images_fields| %>
   <%= images_fields.upload :background_image, label: t(".background_image") %>
 <% end %>

--- a/decidim-core/app/cells/decidim/content_blocks/participatory_space_hero_settings_form/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/participatory_space_hero_settings_form/show.erb
@@ -3,6 +3,6 @@
   <%= settings_fields.translated :text_field, :button_url, label: t("decidim.content_blocks.cta_settings_form.button_url") %>
 <% end %>
 
-<% form.fields_for :images, form.object.images do |images_fields| %>
+<% form.fields_for :images, content_block.images_container do |images_fields| %>
   <%= images_fields.upload :background_image, label: t("decidim.content_blocks.cta_settings_form.background_image") %>
 <% end %>

--- a/decidim-core/app/cells/decidim/data_consent/category.erb
+++ b/decidim-core/app/cells/decidim/data_consent/category.erb
@@ -14,9 +14,9 @@
     </label>
 
     <div id="accordion-trigger-<%= category[:slug] %>" data-controls="accordion-panel-<%= category[:slug] %>" aria-labelledby="accordion-title-<%= category[:slug] %>">
-      <h3 id="accordion-title-<%= category[:slug] %>" class="cookies__category-trigger-title">
+      <span id="accordion-title-<%= category[:slug] %>" class="cookies__category-trigger-title">
         <%= category[:title] %>
-      </h3>
+      </span>
 
       <span>
         <%= icon "arrow-down-s-line", class: "cookies__category-trigger-arrow" %>

--- a/decidim-core/app/models/decidim/attachment.rb
+++ b/decidim-core/app/models/decidim/attachment.rb
@@ -9,7 +9,7 @@ module Decidim
     include Traceable
 
     before_save :set_content_type_and_size, if: :attached?
-    before_validation :set_link_content_type_and_size, if: :link?
+    before_validation :set_link_content_type_and_size, if: :editable_link?
 
     translatable_fields :title, :description
     belongs_to :attachment_collection, class_name: "Decidim::AttachmentCollection", optional: true
@@ -67,6 +67,13 @@ module Decidim
     # Returns Boolean.
     def link?
       link.present?
+    end
+
+    # Whether this attachment is a link that can be edited or not.
+    #
+    # Returns Boolean.
+    def editable_link?
+      !destroyed? && !frozen? && link?
     end
 
     # Which kind of file this is.

--- a/decidim-core/app/packs/src/decidim/dropdown_menu.js
+++ b/decidim-core/app/packs/src/decidim/dropdown_menu.js
@@ -9,6 +9,14 @@ document.addEventListener("DOMContentLoaded", () => {
       dropdownMobileDiv.setAttribute("role", "dialog")
     }, 300)
   }
+
+  // changes the value "menu" of role attribute set by a11y on div dropdown-menu-filters which is inappropriate because the filter panel contains complex form elements, not menuitem children as required by the menu role
+  const dropdownFiltersDiv = document.querySelector("#dropdown-menu-filters");
+  if (dropdownFiltersDiv) {
+    setTimeout(() => {
+      dropdownFiltersDiv.setAttribute("role", "group")
+    }, 300)
+  }
   const triggerButtonMobile = document.querySelector("#dropdown-trigger-links-mobile");
   if (triggerButtonMobile) {
     triggerButtonMobile.addEventListener("click", () => {

--- a/decidim-core/app/presenters/decidim/menu_item_presenter.rb
+++ b/decidim-core/app/presenters/decidim/menu_item_presenter.rb
@@ -26,11 +26,11 @@ module Decidim
     delegate :content_tag, :safe_join, :link_to, :active_link_to_class, :is_active_link?, :icon, to: :@view
 
     def render
-      content_tag :li, role: :menuitem, class: link_wrapper_classes do
+      content_tag :li, role: :none, class: link_wrapper_classes do
         output = if url == "#"
-                   [content_tag(:span, composed_label, class: "sidebar-menu__item-disabled")]
+                   [content_tag(:span, composed_label, class: "sidebar-menu__item-disabled", role: "menuitem")]
                  else
-                   [link_to(composed_label, url, link_options)]
+                   [link_to(composed_label, url, link_options.merge(role: "menuitem"))]
                  end
         output.push(@view.send(:simple_menu, **@menu_item.submenu).render) if @menu_item.submenu
 

--- a/decidim-core/app/views/decidim/pages/index.html.erb
+++ b/decidim-core/app/views/decidim/pages/index.html.erb
@@ -42,7 +42,7 @@ edit_link(
                 <div id="accordion-panel-<%= ix %>" class="page__accordion-panel" aria-hidden="true">
                   <ul role="menu">
                     <% topic.pages.each do |page| %>
-                      <li role="menuitem"><%= link_to translated_attribute(page.title), page_path(page), class: "text-secondary" %></li>
+                      <li><%= link_to translated_attribute(page.title), page_path(page), class: "text-secondary", role: "menuitem" %></li>
                     <% end %>
                   </ul>
                 </div>

--- a/decidim-core/app/views/decidim/shared/_filters.html.erb
+++ b/decidim-core/app/views/decidim/shared/_filters.html.erb
@@ -14,13 +14,13 @@
 
     <div id="dropdown-menu-filters">
       <% if local_assigns.has_key?(:skip_to_id) %>
-        <%= link_to t("skip", scope: "decidim.shared.filter_form_help"), "##{skip_to_id}", class: "filter-skip", role: "menuitem", "data-skip-to-content": true %>
+        <%= link_to t("skip", scope: "decidim.shared.filter_form_help"), "##{skip_to_id}", class: "filter-skip", "data-skip-to-content": true %>
       <% end %>
 
-      <p id="filter-help-text" class="filter-help" role="menuitem" aria-disabled="true"><%= t("help", scope: "decidim.shared.filter_form_help") %></p>
+      <p id="filter-help-text" class="filter-help" aria-disabled="true"><%= t("help", scope: "decidim.shared.filter_form_help") %></p>
 
       <% if local_assigns.has_key?(:search_variable) %>
-        <div class="filter-search filter-container" role="menuitem">
+        <div class="filter-search filter-container">
           <%= form.search_field search_variable,
                                 label: false,
                                 placeholder: search_label,

--- a/decidim-core/app/views/decidim/shared/filters/_check_boxes_tree.html.erb
+++ b/decidim-core/app/views/decidim/shared/filters/_check_boxes_tree.html.erb
@@ -1,4 +1,4 @@
-<div class="filter-container" role="menuitem">
+<div class="filter-container">
   <button id="trigger-menu-<%= id %>" data-controls="panel-dropdown-menu-<%= id %>" data-open="false" data-open-md="true">
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>

--- a/decidim-core/app/views/decidim/shared/filters/_collection.html.erb
+++ b/decidim-core/app/views/decidim/shared/filters/_collection.html.erb
@@ -1,4 +1,4 @@
-<div class="filter-container" role="menuitem">
+<div class="filter-container">
   <button id="trigger-menu-<%= id %>" data-controls="panel-dropdown-menu-<%= id %>" data-open="false" data-open-md="true">
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>

--- a/decidim-core/lib/decidim/core/seeds.rb
+++ b/decidim-core/lib/decidim/core/seeds.rb
@@ -106,7 +106,7 @@ module Decidim
       end
 
       def create_organization!
-        smtp_label = ENV.fetch("SMTP_FROM_LABEL", ::Faker::X.unique.screen_name)
+        smtp_label = ENV.fetch("SMTP_FROM_LABEL", ::Faker::Internet.unique.username)
         smtp_email = ENV.fetch("SMTP_FROM_EMAIL", ::Faker::Internet.email)
 
         primary_color, secondary_color, tertiary_color = [
@@ -134,7 +134,7 @@ module Decidim
             from: "#{smtp_label} <#{smtp_email}>",
             from_email: smtp_email,
             from_label: smtp_label,
-            user_name: ENV.fetch("SMTP_USERNAME", ::Faker::X.unique.screen_name),
+            user_name: ENV.fetch("SMTP_USERNAME", ::Faker::Internet.unique.username),
             encrypted_password: Decidim::AttributeEncryptor.encrypt(ENV.fetch("SMTP_PASSWORD", ::Faker::Internet.password(min_length: 8))),
             address: ENV.fetch("SMTP_ADDRESS", nil) || ENV.fetch("DECIDIM_HOST", "localhost"),
             port: ENV.fetch("SMTP_PORT", nil) || ENV.fetch("DECIDIM_SMTP_PORT", "25")
@@ -202,7 +202,7 @@ module Decidim
       def create_user_group!(user:, verified_at:)
         user_group = Decidim::UserGroup.create!(
           name: ::Faker::Company.unique.name,
-          nickname: ::Faker::X.unique.screen_name,
+          nickname: ::Faker::Internet.unique.username,
           email: ::Faker::Internet.email,
           confirmed_at: Time.current,
           extended_data: {

--- a/decidim-core/lib/decidim/core/seeds.rb
+++ b/decidim-core/lib/decidim/core/seeds.rb
@@ -200,9 +200,10 @@ module Decidim
       end
 
       def create_user_group!(user:, verified_at:)
+        group_name = ::Faker::Company.unique.name
         user_group = Decidim::UserGroup.create!(
-          name: ::Faker::Company.unique.name,
-          nickname: ::Faker::Internet.unique.username,
+          name: group_name,
+          nickname: Decidim::UserGroup.nicknamize(group_name, user.organization.id),
           email: ::Faker::Internet.email,
           confirmed_at: Time.current,
           extended_data: {

--- a/decidim-core/lib/decidim/seeds.rb
+++ b/decidim-core/lib/decidim/seeds.rb
@@ -19,9 +19,10 @@ module Decidim
 
     def find_or_initialize_user_by(email:)
       user = Decidim::User.find_or_initialize_by(email:)
+      name = ::Faker::Name.name
       user.update!(
-        name: ::Faker::Name.name,
-        nickname: ::Faker::X.unique.screen_name,
+        name:,
+        nickname: Decidim::User.nicknamize(name, organization.id),
         password: "decidim123456789",
         organization:,
         confirmed_at: Time.current,

--- a/decidim-core/spec/lib/map/autocomplete_spec.rb
+++ b/decidim-core/spec/lib/map/autocomplete_spec.rb
@@ -54,6 +54,8 @@ module Decidim
       end
 
       before do
+        Decidim::Map.reset_utility_configuration!
+        GeocoderHelpers.configure_maps
         allow(template).to receive(:current_organization).and_return(organization)
       end
 

--- a/decidim-generators/lib/decidim/generators/app_templates/package.json
+++ b/decidim-generators/lib/decidim/generators/app_templates/package.json
@@ -15,5 +15,8 @@
   },
   "browserslist": [
     "extends @decidim/browserslist-config"
-  ]
+  ],
+  "overrides": {
+    "serialize-javascript": "^6.0.2"
+  }
 }

--- a/decidim-meetings/spec/shared/manage_invites_examples.rb
+++ b/decidim-meetings/spec/shared/manage_invites_examples.rb
@@ -111,6 +111,7 @@ shared_examples "manage invites" do
           invite_existing_user registered_user
 
           relogin_as registered_user
+          perform_enqueued_jobs
 
           visit last_email_link
 
@@ -121,6 +122,7 @@ shared_examples "manage invites" do
           invite_existing_user registered_user
 
           relogin_as registered_user
+          perform_enqueued_jobs
 
           visit last_email_first_link
 
@@ -135,6 +137,7 @@ shared_examples "manage invites" do
           invite_unregistered_user name: registered_user.name, email: registered_user.email
 
           relogin_as registered_user
+          perform_enqueued_jobs
 
           visit last_email_link
 
@@ -145,6 +148,7 @@ shared_examples "manage invites" do
           invite_unregistered_user name: registered_user.name, email: registered_user.email
 
           relogin_as registered_user
+          perform_enqueued_jobs
 
           visit last_email_first_link
 

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -152,8 +152,8 @@ module Decidim
         end
       end
 
-      def random_nickname
-        "#{::Faker::X.unique.screen_name}-#{SecureRandom.hex(4)}"[0, 20]
+      def random_nickname(name = nil)
+        Decidim::UserGroup.nicknamize(name || ::Faker::Name.name, organization.id)
       end
 
       def random_email(suffix:)
@@ -165,9 +165,10 @@ module Decidim
       def create_emendation!(proposal:)
         author = find_or_initialize_user_by(email: random_email(suffix: "amendment"))
 
+        group_name = ::Faker::Name.name
         group = Decidim::UserGroup.create!(
-          name: ::Faker::Name.name,
-          nickname: random_nickname,
+          name: group_name,
+          nickname: random_nickname(group_name),
           email: ::Faker::Internet.email,
           extended_data: {
             document_number: ::Faker::Code.isbn,

--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
     "jest-localstorage-mock": "^2.4.26",
     "react-test-renderer": "^18.2.0",
     "yaml-jest": "^1.2.0"
+  },
+  "overrides": {
+    "serialize-javascript": "^6.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
   "dependencies": {
     "@decidim/browserslist-config": "file:packages/browserslist-config",
     "@decidim/core": "file:packages/core",
-    "@decidim/webpacker": "file:packages/webpacker"
+    "@decidim/webpacker": "file:packages/webpacker",
+    "workbox-webpack-plugin": "7.0.0"
   },
   "devDependencies": {
     "@decidim/dev": "file:packages/dev",


### PR DESCRIPTION
#### :tophat: What? Why?
This PR

- Prevents calling the set_link_content_type_and_size callback of the Decidim::Attachment model if the instance is not editable because is in frozen state or destroyed.
- This change allows admins to delete attachments with links from the admin panel
- Adds a test to check the fix.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to#?
- Fixes https://github.com/decidim/decidim/pull/15994

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots

https://github.com/user-attachments/assets/ab199e8a-17f1-4aac-a53d-f33aabbb49d8


![Description](URL)

:hearts: Thank you!
