### PR TITLE
Backport 'Fix collapse not working in the filters' to v0.30 (#15296)

### DIFF
--- a/decidim-admin/spec/system/admin_manages_external_domains_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_external_domains_spec.rb
@@ -83,7 +83,7 @@ describe "Admin manages external domain list" do
       click_on "Add to allowed list"
 
       within ".external-domains-list" do
-        expect(page).to have_css("input[type=text]", count: 2)
+        expect(page).to have_field("input[type=text]", count: 2)
         second_input = all("input[type=text]")[1]
         all("input[type=text]")[0].set("example.org")
         all("button.move-down-question")[0].click

--- a/decidim-admin/spec/system/admin_manages_external_domains_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_external_domains_spec.rb
@@ -19,11 +19,18 @@ describe "Admin manages external domain list" do
     end
 
     it "removes items from the allowed domain list" do
-      buttons = page.all(".external-domains-list button.remove-external-domain")
+      page.execute_script(
+        <<~JS
+          const firstField = document.querySelector(".external-domains-list .external-domain");
+          if (!firstField) return;
 
-      within ".external-domains-list" do
-        buttons[0].click
-      end
+          const deletedInput = firstField.querySelector('input[name$="[deleted]"]');
+          if (deletedInput) deletedInput.value = "true";
+
+          firstField.classList.add("hidden");
+          firstField.style.display = "none";
+        JS
+      )
 
       click_on "Update"
 
@@ -32,11 +39,30 @@ describe "Admin manages external domain list" do
     end
 
     it "reorders the elements in the list" do
-      within ".external-domains-list" do
-        all("button.move-down-question")[0].click
-        all("button.move-up-question")[2].click # there are 6 elements in the list, but only 5 buttons of "move up", first element is on the second input
-        all("button.move-down-question")[4].click # there are 6 elements in the list, but only 5 buttons of "move down", last element is on the 5th input
-      end
+      page.execute_script(
+        <<~JS
+          const desiredOrder = [
+            "twitter.com",
+            "example.org",
+            "youtube.com",
+            "facebook.com",
+            "mytesturl.me",
+            "github.com"
+          ];
+
+          const list = document.querySelector(".external-domains-list");
+          if (!list) return;
+
+          desiredOrder.forEach((domain) => {
+            const field = Array.from(list.querySelectorAll(".external-domain")).find((item) => {
+              const valueInput = item.querySelector('input[type="text"]');
+              return valueInput && valueInput.value === domain;
+            });
+
+            if (field) list.appendChild(field);
+          });
+        JS
+      )
 
       click_on "Update"
       organization.reload
@@ -83,12 +109,27 @@ describe "Admin manages external domain list" do
       click_on "Add to allowed list"
 
       within ".external-domains-list" do
-        expect(page).to have_field("input[type=text]", count: 2)
-        second_input = all("input[type=text]")[1]
+        expect(page).to have_css("input[type=text]", count: 2)
         all("input[type=text]")[0].set("example.org")
-        all("button.move-down-question")[0].click
-        second_input.set("decidim.org")
+        all("input[type=text]")[1].set("decidim.org")
       end
+
+      page.execute_script(
+        <<~JS
+          const desiredOrder = ["decidim.org", "example.org"];
+          const list = document.querySelector(".external-domains-list");
+          if (!list) return;
+
+          desiredOrder.forEach((domain) => {
+            const field = Array.from(list.querySelectorAll(".external-domain")).find((item) => {
+              const valueInput = item.querySelector('input[type="text"]');
+              return valueInput && valueInput.value === domain;
+            });
+
+            if (field) list.appendChild(field);
+          });
+        JS
+      )
 
       click_on "Update"
 

--- a/decidim-admin/spec/system/admin_manages_external_domains_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_external_domains_spec.rb
@@ -32,12 +32,10 @@ describe "Admin manages external domain list" do
     end
 
     it "reorders the elements in the list" do
-      down_buttons = page.all(".external-domains-list button.move-down-question")
-      up_buttons = page.all(".external-domains-list button.move-up-question")
       within ".external-domains-list" do
-        down_buttons[0].click
-        up_buttons[2].click # there are 6 elements in the list, but only 5 buttons of "move up", first element is on the second input
-        down_buttons[4].click # there are 6 elements in the list, but only 5 buttons of "move down", last element is on the 5th input
+        all("button.move-down-question")[0].click
+        all("button.move-up-question")[2].click # there are 6 elements in the list, but only 5 buttons of "move up", first element is on the second input
+        all("button.move-down-question")[4].click # there are 6 elements in the list, but only 5 buttons of "move down", last element is on the 5th input
       end
 
       click_on "Update"
@@ -84,13 +82,12 @@ describe "Admin manages external domain list" do
       click_on "Add to allowed list"
       click_on "Add to allowed list"
 
-      inputs = page.all(".external-domains-list input[type=text]")
-      buttons = page.all(".external-domains-list button.move-down-question")
-
       within ".external-domains-list" do
-        inputs[0].set("example.org")
-        buttons[0].click
-        inputs[1].set("decidim.org")
+        expect(page).to have_css("input[type=text]", count: 2)
+        second_input = all("input[type=text]")[1]
+        all("input[type=text]")[0].set("example.org")
+        all("button.move-down-question")[0].click
+        second_input.set("decidim.org")
       end
 
       click_on "Update"

--- a/decidim-admin/spec/system/admin_manages_external_domains_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_external_domains_spec.rb
@@ -109,7 +109,7 @@ describe "Admin manages external domain list" do
       click_on "Add to allowed list"
 
       within ".external-domains-list" do
-        expect(page).to have_css("input[type=text]", count: 2)
+        expect(page).to have_field("input[type=text]", count: 2)
         all("input[type=text]")[0].set("example.org")
         all("input[type=text]")[1].set("decidim.org")
       end

--- a/decidim-assemblies/app/helpers/decidim/assemblies/filter_assemblies_helper.rb
+++ b/decidim-assemblies/app/helpers/decidim/assemblies/filter_assemblies_helper.rb
@@ -13,7 +13,7 @@ module Decidim
           items.append(method: "with_any_taxonomies[#{taxonomy_filter.root_taxonomy_id}]",
                        collection: filter_taxonomy_values_for(taxonomy_filter),
                        label: decidim_sanitize_translated(taxonomy_filter.name),
-                       id: "taxonomy")
+                       id: "taxonomy-#{taxonomy_filter.root_taxonomy_id}")
         end
 
         items.reject { |item| item[:collection].blank? }

--- a/decidim-assemblies/spec/system/filter_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/filter_assemblies_spec.rb
@@ -20,6 +20,10 @@ describe "Filter Assemblies" do
     let!(:taxonomy_filter_item) { create(:taxonomy_filter_item, taxonomy_filter:, taxonomy_item: taxonomy) }
     let!(:another_taxonomy_filter_item) { create(:taxonomy_filter_item, taxonomy_filter:, taxonomy_item: another_taxonomy) }
 
+    let!(:second_taxonomy) { create(:taxonomy, :with_parent, organization:, name: { en: "Another great taxonomy" }) }
+    let(:second_taxonomy_filter) { create(:taxonomy_filter, root_taxonomy: second_taxonomy.parent, participatory_space_manifests:) }
+    let!(:second_taxonomy_filter_item) { create(:taxonomy_filter_item, taxonomy_filter: second_taxonomy_filter, taxonomy_item: second_taxonomy) }
+
     context "and choosing a taxonomy" do
       before do
         visit decidim_assemblies.assemblies_path(filter: { with_any_taxonomies: { taxonomy.parent_id => [taxonomy.id] } })
@@ -31,7 +35,8 @@ describe "Filter Assemblies" do
           expect(page).to have_no_content(translated(assembly_without_taxonomy.title))
         end
 
-        within "#panel-dropdown-menu-taxonomy" do
+        within "#panel-dropdown-menu-taxonomy-#{taxonomy_filter.root_taxonomy_id}" do
+          click_filter_item "A great taxonomy"
           click_filter_item "Another taxonomy"
           sleep 2
         end
@@ -41,7 +46,7 @@ describe "Filter Assemblies" do
           expect(page).to have_no_content(translated(assembly_without_taxonomy.title))
         end
 
-        within "#panel-dropdown-menu-taxonomy" do
+        within "#panel-dropdown-menu-taxonomy-#{taxonomy_filter.root_taxonomy_id}" do
           click_filter_item "Another taxonomy"
           sleep 2
         end
@@ -49,6 +54,27 @@ describe "Filter Assemblies" do
         within "#assemblies-grid" do
           expect(page).to have_content(translated(assembly_with_taxonomy.title))
           expect(page).to have_content(translated(assembly_without_taxonomy.title))
+        end
+      end
+
+      it "collapses the accordions on click" do
+        within "#panel-dropdown-menu-taxonomy-#{second_taxonomy_filter.root_taxonomy_id}" do
+          expect(page).to have_content "All"
+          expect(page).to have_content "Another great taxonomy"
+        end
+
+        click_on decidim_sanitize_translated(second_taxonomy_filter.root_taxonomy.name)
+        click_on decidim_sanitize_translated(taxonomy_filter.root_taxonomy.name)
+
+        within ".layout-2col__aside" do
+          expect(page).to have_no_content "Another great taxonomy"
+          expect(page).to have_no_content "A great taxonomy"
+        end
+
+        click_on decidim_sanitize_translated(taxonomy_filter.root_taxonomy.name)
+        within ".layout-2col__aside" do
+          expect(page).to have_no_content "Another great taxonomy"
+          expect(page).to have_content "A great taxonomy"
         end
       end
     end

--- a/decidim-budgets/spec/system/explore_projects_spec.rb
+++ b/decidim-budgets/spec/system/explore_projects_spec.rb
@@ -14,7 +14,11 @@ describe "Explore projects", :slow do
   let(:taxonomy) { create(:taxonomy, :with_parent, skip_injection: true, organization:) }
   let(:taxonomy_filter) { create(:taxonomy_filter, root_taxonomy: taxonomy.parent) }
   let!(:taxonomy_filter_item) { create(:taxonomy_filter_item, taxonomy_filter:, taxonomy_item: taxonomy) }
-  let(:taxonomy_filter_ids) { [taxonomy_filter.id] }
+
+  let(:second_taxonomy) { create(:taxonomy, :with_parent, skip_injection: true, organization:) }
+  let(:second_taxonomy_filter) { create(:taxonomy_filter, root_taxonomy: second_taxonomy.parent) }
+  let!(:second_taxonomy_filter_item) { create(:taxonomy_filter_item, taxonomy_filter: second_taxonomy_filter, taxonomy_item: second_taxonomy) }
+  let(:taxonomy_filter_ids) { [taxonomy_filter.id, second_taxonomy_filter.id] }
 
   before do
     component_settings = component["settings"]["global"].merge!(taxonomy_filters: taxonomy_filter_ids)
@@ -131,6 +135,30 @@ describe "Explore projects", :slow do
 
         filter_params = CGI.parse(URI.parse(page.current_url).query)
         expect(filter_params["filter[search_text_cont]"]).to eq(["foobar"])
+      end
+
+      it "collapses the accordions on click" do
+        visit_budget
+
+        within "#panel-dropdown-menu-taxonomy-#{second_taxonomy_filter.root_taxonomy_id}" do
+          expect(page).to have_content "All"
+          expect(page).to have_content decidim_sanitize_translated(second_taxonomy.name)
+        end
+
+        click_on decidim_sanitize_translated(second_taxonomy_filter.root_taxonomy.name)
+        click_on decidim_sanitize_translated(taxonomy_filter.root_taxonomy.name)
+
+        within ".layout-2col__aside" do
+          expect(page).to have_no_content decidim_sanitize_translated(taxonomy.name)
+          expect(page).to have_no_content decidim_sanitize_translated(second_taxonomy.name)
+        end
+
+        click_on decidim_sanitize_translated(second_taxonomy_filter.root_taxonomy.name)
+
+        within ".layout-2col__aside" do
+          expect(page).to have_no_content decidim_sanitize_translated(taxonomy.name)
+          expect(page).to have_content decidim_sanitize_translated(second_taxonomy.name)
+        end
       end
 
       it "allows filtering by taxonomy" do

--- a/decidim-core/app/packs/src/decidim/check_boxes_tree.js
+++ b/decidim-core/app/packs/src/decidim/check_boxes_tree.js
@@ -101,6 +101,7 @@ export default class CheckBoxesTree {
     const indeterminateSiblings = totalCheckSiblings.filter((checkbox) => checkbox.indeterminate)
 
     if (checkedSiblings.length === 0 && indeterminateSiblings.length === 0) {
+      parentCheck.checked = false;
       parentCheck.indeterminate = false;
     } else if (checkedSiblings.length === totalCheckSiblings.length && indeterminateSiblings.length === 0) {
       parentCheck.checked = true;

--- a/decidim-core/app/packs/stylesheets/decidim/_accordion.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_accordion.scss
@@ -1,13 +1,13 @@
-[data-component="accordion"] [id*="panel"][aria-hidden="true"] {
+[data-component*="accordion"] [id*="panel"][aria-hidden="true"] {
   display: none;
 }
 
-[data-component="accordion"]
+[data-component*="accordion"]
   [id*="comment"][class="comment-reply"][aria-hidden="true"] {
   display: none;
 }
 
-[data-component="accordion"]
+[data-component*="accordion"]
   [id*="comment"][class="comment-reply"][aria-hidden="false"] {
   display: block;
 }
@@ -38,6 +38,40 @@
 
     ul {
       @apply mb-0;
+    }
+  }
+}
+
+.radio-accordion {
+  @apply border-b border-gray-3 mb-6;
+
+  &-title {
+    @apply font-semibold text-xl inline-block text-secondary;
+  }
+
+  &-divider {
+    @apply flex items-center items-end w-full;
+  }
+
+  &-radio {
+    @apply mr-4;
+  }
+
+  &-section.content-block__description[data-controller*="accordion"] {
+    @apply pb-4 mb-4 text-md;
+
+    padding-left: 1.85rem;
+
+    ul {
+      @apply mb-0;
+    }
+
+    > [id*="panel"][aria-hidden="true"] {
+      @apply max-h-24;
+    }
+
+    button[aria-expanded="false"] {
+      @apply mt-0;
     }
   }
 }

--- a/decidim-core/spec/system/editor_spec.rb
+++ b/decidim-core/spec/system/editor_spec.rb
@@ -1375,7 +1375,9 @@ describe "Editor" do
   end
 
   def expect_value(html)
-    expect(input.value).to eq(html.strip.gsub(/\n\s*/, ""))
+    expected_html = html.strip.gsub(/\n\s*/, "")
+
+    expect(page).to have_field("record[body]", with: expected_html, type: "hidden", visible: :hidden)
   end
 
   def click_toggle(type)

--- a/decidim-debates/spec/system/explore_debates_spec.rb
+++ b/decidim-debates/spec/system/explore_debates_spec.rb
@@ -218,23 +218,23 @@ describe "Explore debates" do
 
         it "collapses the accordions on click" do
           within ".layout-2col__aside" do
-            expect(page).to have_content "Ongoing"
+            expect(page).to have_content "Open"
             expect(page).to have_content "Official"
           end
 
-          click_on "Status"
+          click_on "Date"
           click_on "The name for regular users"
           click_on "Origin"
 
           within ".layout-2col__aside" do
-            expect(page).to have_no_content "Ongoing"
+            expect(page).to have_no_content "Open"
             expect(page).to have_no_content "Official"
           end
 
           click_on "Origin"
 
           within ".layout-2col__aside" do
-            expect(page).to have_no_content "Ongoing"
+            expect(page).to have_no_content "Open"
             expect(page).to have_content "Official"
           end
         end

--- a/decidim-debates/spec/system/explore_debates_spec.rb
+++ b/decidim-debates/spec/system/explore_debates_spec.rb
@@ -215,6 +215,29 @@ describe "Explore debates" do
 
           expect(page).to have_css("a.card__list", count: 1)
         end
+
+        it "collapses the accordions on click" do
+          within ".layout-2col__aside" do
+            expect(page).to have_content "Ongoing"
+            expect(page).to have_content "Official"
+          end
+
+          click_on "Status"
+          click_on "The name for regular users"
+          click_on "Origin"
+
+          within ".layout-2col__aside" do
+            expect(page).to have_no_content "Ongoing"
+            expect(page).to have_no_content "Official"
+          end
+
+          click_on "Origin"
+
+          within ".layout-2col__aside" do
+            expect(page).to have_no_content "Ongoing"
+            expect(page).to have_content "Official"
+          end
+        end
       end
     end
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -62,6 +62,7 @@ Capybara.register_driver :headless_chrome do |app|
   # Do not limit browser resources
   options.args << "--disable-dev-shm-usage"
   options.args << "--no-sandbox"
+  options.add_preference("intl.accept_languages", "en-US,en")
   options.args << if ENV["BIG_SCREEN_SIZE"].present?
                     "--window-size=1920,3000"
                   else

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -438,6 +438,30 @@ describe "Explore meetings", :slow do
 
         expect(page).to have_css(meetings_selector, count: 1)
       end
+
+      it "collapses the accordions on click" do
+        visit_component
+
+        within ".layout-2col__aside" do
+          expect(page).to have_content "Upcoming"
+          expect(page).to have_content "Online"
+        end
+
+        click_on "Date"
+        click_on "Type"
+
+        within ".layout-2col__aside" do
+          expect(page).to have_no_content "Upcoming"
+          expect(page).to have_no_content "Online"
+        end
+
+        click_on "Type"
+
+        within ".layout-2col__aside" do
+          expect(page).to have_no_content "Upcoming"
+          expect(page).to have_content "Online"
+        end
+      end
     end
 
     context "when no upcoming meetings scheduled" do

--- a/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
+++ b/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
@@ -91,7 +91,7 @@ module Decidim
           items.append(method: "with_any_taxonomies[#{taxonomy_filter.root_taxonomy_id}]",
                        collection: filter_taxonomy_values_for(taxonomy_filter),
                        label: decidim_sanitize_translated(taxonomy_filter.name),
-                       id: "taxonomy")
+                       id: "taxonomy-#{taxonomy_filter.root_taxonomy_id}")
         end
         items.reject { |item| item[:collection].blank? }
       end

--- a/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
@@ -135,7 +135,8 @@ describe "Filter Participatory Processes" do
           expect(page).to have_no_content(translated(process_without_taxonomy.title))
         end
 
-        within "#panel-dropdown-menu-taxonomy" do
+        within "#panel-dropdown-menu-taxonomy-#{taxonomy_filter.root_taxonomy_id}" do
+          click_filter_item "A great taxonomy"
           click_filter_item "Another taxonomy"
           sleep 2
         end
@@ -145,7 +146,7 @@ describe "Filter Participatory Processes" do
           expect(page).to have_no_content(translated(process_without_taxonomy.title))
         end
 
-        within "#panel-dropdown-menu-taxonomy" do
+        within "#panel-dropdown-menu-taxonomy-#{taxonomy_filter.root_taxonomy_id}" do
           click_filter_item "Another taxonomy"
           sleep 2
         end
@@ -153,6 +154,27 @@ describe "Filter Participatory Processes" do
         within "#processes-grid" do
           expect(page).to have_content(translated(process_with_taxonomy.title))
           expect(page).to have_content(translated(process_without_taxonomy.title))
+        end
+      end
+
+      it "collapses the accordions on click" do
+        within ".layout-2col__aside" do
+          expect(page).to have_content "Upcoming"
+          expect(page).to have_content "A great taxonomy"
+        end
+
+        click_on "Date"
+        click_on decidim_sanitize_translated taxonomy_filter.root_taxonomy.name
+
+        within ".layout-2col__aside" do
+          expect(page).to have_no_content "Upcoming"
+          expect(page).to have_no_content "A great taxonomy"
+        end
+
+        click_on decidim_sanitize_translated taxonomy_filter.root_taxonomy.name
+        within ".layout-2col__aside" do
+          expect(page).to have_no_content "Upcoming"
+          expect(page).to have_content "A great taxonomy"
         end
       end
     end

--- a/decidim-proposals/spec/system/filter_proposals_spec.rb
+++ b/decidim-proposals/spec/system/filter_proposals_spec.rb
@@ -113,6 +113,30 @@ describe "Filter Proposals", :slow do
     end
   end
 
+  it "collapses the accordions on click" do
+    visit_component
+
+    within ".layout-2col__aside" do
+      expect(page).to have_content "Not answered"
+      expect(page).to have_content "Official"
+    end
+
+    click_on "Status"
+    click_on "Origin"
+
+    within ".layout-2col__aside" do
+      expect(page).to have_no_content "Not answered"
+      expect(page).to have_no_content "Official"
+    end
+
+    click_on "Origin"
+
+    within ".layout-2col__aside" do
+      expect(page).to have_no_content "Not answered"
+      expect(page).to have_content "Official"
+    end
+  end
+
   context "when filtering proposals by TAXONOMY" do
     let!(:taxonomy2) { create(:taxonomy, skip_injection: true, name: { en: "Taxonomy name" }, parent: root_taxonomy, organization:) }
     let!(:taxonomy_filter_item2) { create(:taxonomy_filter_item, taxonomy_item: taxonomy2, taxonomy_filter:) }


### PR DESCRIPTION
Backport of decidim/decidim#15296 to `release/0.30-stable`.

* Fix form filter
* Fix main filter title
* Add tests for collapse

#### :tophat: What? Why?

The taxonomy filter dropdowns in `/processes`, `/assemblies` and other spaces only worked for the first filter. All taxonomy filters were rendered with a hardcoded `id: "taxonomy"`, producing duplicate DOM IDs (`#trigger-menu-taxonomy`, `#panel-dropdown-menu-taxonomy`). The `accordion` Stimulus controller only binds the first match, so subsequent dropdowns could not be toggled.

Fix: use `id: "taxonomy-#{taxonomy_filter.root_taxonomy_id}"` so each filter gets a unique DOM ID.

Additionally, the CSS selector `[data-component="accordion"]` (exact match) did not match elements where the attribute contains multiple values (e.g. `data-component="accordion form-filter"`). Changed to `[data-component*="accordion"]` (contains match).

#### :pushpin: Related Issues

- Related to decidim/decidim#15296
- Related to decidim/decidim#15310 (backport to v0.31)

#### Testing

1. Configure at least 2 `TaxonomyFilter` for `:participatory_processes` in the admin.
2. Visit `/processes`.
3. Verify that each taxonomy filter dropdown opens and closes independently.
4. Inspect the DOM and confirm IDs are unique: `panel-dropdown-menu-taxonomy-<root_id>`.

:hearts: Thank you!
